### PR TITLE
Auth passthrough (auth_query)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,14 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_INITDB_ARGS: --auth-local=scram-sha-256 --auth-host=scram-sha-256 --auth=scram-sha-256
 
+      - image: postgres:14
+        command: ["postgres", "-p", "10432", "-c", "shared_preload_libraries=pg_stat_statements"]
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: --auth-local=md5 --auth-host=md5 --auth=md5
+
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -19,6 +19,7 @@ PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 5432 -U postgres -f tests/sharding/q
 PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 7432 -U postgres -f tests/sharding/query_routing_setup.sql
 PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 8432 -U postgres -f tests/sharding/query_routing_setup.sql
 PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 9432 -U postgres -f tests/sharding/query_routing_setup.sql
+PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 10432 -U postgres -f tests/sharding/query_routing_setup.sql
 
 PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard0 -i
 PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard1 -i

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+hard_tabs = false

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -175,10 +175,40 @@ Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DAT
 ### admin_password
 ```
 path: general.admin_password
-default: "admin_pass"
+default: <UNSET>
 ```
 
 Password to access the virtual administrative database
+
+### auth_query (experimental)
+```
+path: general.auth_query
+default: <UNSET>
+```
+
+Query to be sent to servers to obtain the hash used for md5 authentication. The connection will be
+established using the database configured in the pool. This parameter is inherited by every pool
+and can be redefined in pool configuration.
+
+### auth_query_user (experimental)
+```
+path: general.auth_query_user
+default: <UNSET>
+```
+
+User to be used for connecting to servers to obtain the hash used for md5 authentication by sending the query
+specified in `auth_query_user`. The connection will be established using the database configured in the pool.
+This parameter is inherited by every pool and can be redefined in pool configuration.
+
+### auth_query_password (experimental)
+```
+path: general.auth_query_password
+default: <UNSET>
+```
+
+Password to be used for connecting to servers to obtain the hash used for md5 authentication by sending the query
+specified in `auth_query_user`. The connection will be established using the database configured in the pool.
+This parameter is inherited by every pool and can be redefined in pool configuration.
 
 ## `pools.<pool_name>` Section
 
@@ -280,6 +310,30 @@ default: 3000
 ```
 
 Connect timeout can be overwritten in the pool
+
+### auth_query (experimental)
+```
+path: general.auth_query
+default: <UNSET>
+```
+
+Auth query can be overwritten in the pool
+
+### auth_query_user (experimental)
+```
+path: general.auth_query_user
+default: <UNSET>
+```
+
+Auth query user can be overwritten in the pool
+
+### auth_query_password (experimental)
+```
+path: general.auth_query_password
+default: <UNSET>
+```
+
+Auth query password can be overwritten in the pool
 
 ## `pools.<pool_name>.users.<user_index>` Section
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -93,6 +99,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -256,6 +268,12 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fnv"
@@ -732,12 +750,13 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "atomic_enum",
- "base64",
+ "base64 0.21.0",
  "bb8",
  "bytes",
  "chrono",
  "env_logger",
  "exitcode",
+ "fallible-iterator",
  "futures",
  "hmac",
  "hyper",
@@ -749,6 +768,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "phf",
+ "postgres-protocol",
  "rand",
  "regex",
  "rustls-pemfile",
@@ -817,6 +837,24 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -945,7 +983,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "6227a8d6fdb862bcb100c4314d0d9579e5cd73fa6df31a2e6f6e1acd3c5f1207"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
@@ -38,6 +37,8 @@ futures = "0.3"
 socket2 = { version = "0.4.7", features = ["all"] }
 nix = "0.26.2"
 atomic_enum = "0.2.0"
+postgres-protocol = "0.6.4"
+fallible-iterator = "0.2"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ PostgreSQL pooler and proxy (like PgBouncer) with support for sharding, load bal
 | Sharding using comments parsing/Regex | **Experimental** | Clients can include shard information (sharding key, shard ID) in the query comments. |
 | Automatic sharding | **Experimental** | PgCat can parse queries, detect sharding keys automatically, and route queries to the correct shard. |
 | Mirroring | **Experimental** | Mirror queries between multiple databases in order to test servers with realistic production traffic. |
+| Auth passthrough | **Experimental** | MD5 password authentication can be configured to use an `auth_query` so no cleartext passwords are needed in the config file.                         |
 
 
 ## Status

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -58,6 +58,13 @@ services:
       POSTGRES_INITDB_ARGS: --auth-local=scram-sha-256 --auth-host=scram-sha-256 --auth=scram-sha-256
       PGPORT: 9432
     command: ["postgres", "-p", "9432", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "pg_stat_statements.max=100000"]
+  pg5:
+    <<: *common-definition-pg
+    environment:
+      <<: *common-env-pg
+      POSTGRES_INITDB_ARGS: --auth-local=md5 --auth-host=md5 --auth=md5
+      PGPORT: 10432
+    command: ["postgres", "-p", "5432", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "pg_stat_statements.max=100000"]
 
   toxiproxy:
     build: .
@@ -71,6 +78,7 @@ services:
       - pg2
       - pg3
       - pg4
+      - pg5
 
   pgcat-shell:
     stdin_open: true

--- a/src/auth_passthrough.rs
+++ b/src/auth_passthrough.rs
@@ -1,0 +1,107 @@
+use crate::errors::Error;
+use crate::server::Server;
+use log::debug;
+
+#[derive(Clone, Debug)]
+pub struct AuthPassthrough {
+    password: String,
+    query: String,
+    user: String,
+}
+
+impl AuthPassthrough {
+    /// Initializes an AuthPassthrough.
+    pub fn new(query: &str, user: &str, password: &str) -> Self {
+        AuthPassthrough {
+            password: password.to_string(),
+            query: query.to_string(),
+            user: user.to_string(),
+        }
+    }
+
+    /// Returns an AuthPassthrough given the pool configuration.
+    /// If any of required values is not set, None is returned.
+    pub fn from_pool_config(pool_config: &crate::config::Pool) -> Option<Self> {
+        if pool_config.is_auth_query_configured() {
+            return Some(AuthPassthrough::new(
+                pool_config.auth_query.as_ref().unwrap(),
+                pool_config.auth_query_user.as_ref().unwrap(),
+                pool_config.auth_query_password.as_ref().unwrap(),
+            ));
+        }
+
+        None
+    }
+
+    /// Returns an AuthPassthrough given the pool settings.
+    /// If any of required values is not set, None is returned.
+    pub fn from_pool_settings(pool_settings: &crate::pool::PoolSettings) -> Option<Self> {
+        let pool_config = crate::config::Pool {
+            auth_query: pool_settings.auth_query.clone(),
+            auth_query_password: pool_settings.auth_query_password.clone(),
+            auth_query_user: pool_settings.auth_query_user.clone(),
+            ..Default::default()
+        };
+
+        AuthPassthrough::from_pool_config(&pool_config)
+    }
+
+    /// Connects to server and executes auth_query for the specified address.
+    /// If the response is a row with two columns containing the username set in the address.
+    /// and its MD5 hash, the MD5 hash returned.
+    ///
+    /// Note that the query is executed, changing $1 with the name of the user
+    /// this is so we only hold in memory (and transfer) the least amount of 'sensitive' data.
+    /// Also, it is compatible with pgbouncer.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - An Address of the server we want to connect to. The username for the hash will be obtained from this value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pgcat::auth_passthrough::AuthPassthrough;
+    /// use pgcat::config::Address;
+    /// let auth_passthrough = AuthPassthrough::new("SELECT * FROM public.user_lookup('$1');", "postgres", "postgres");
+    /// auth_passthrough.fetch_hash(&Address::default());
+    /// ```
+    ///
+    pub async fn fetch_hash(&self, address: &crate::config::Address) -> Result<String, Error> {
+        let auth_user = crate::config::User {
+            username: self.user.clone(),
+            password: Some(self.password.clone()),
+            pool_size: 1,
+            statement_timeout: 0,
+        };
+
+        let user = &address.username;
+
+        debug!("Connecting to server to obtain auth hashes.");
+        let auth_query = self.query.replace("$1", user);
+        match Server::exec_simple_query(address, &auth_user, &auth_query).await {
+            Ok(password_data) => {
+                if password_data.len() == 2 && password_data.first().unwrap() == user {
+		    if let Some(stripped_hash) = password_data.last().unwrap().to_string().strip_prefix("md5") {
+			Ok(stripped_hash.to_string())
+		    }
+		    else {
+			Err(Error::AuthPassthroughError(
+			    "Obtained hash from auth_query does not seem to be in md5 format.".to_string(),
+			))
+		    }
+                } else {
+                    Err(Error::AuthPassthroughError(
+                        "Data obtained from query does not follow the scheme 'user','hash'."
+                            .to_string(),
+                    ))
+                 }
+            }
+            Err(err) => {
+		Err(Error::AuthPassthroughError(
+		    format!("Error trying to obtain password from auth_query, ignoring hash for user '{}'. Error: {:?}",
+			    user, err)))
+            }
+	}
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -413,12 +413,12 @@ pub struct Pool {
     pub shard_id_regex: Option<String>,
     pub regex_search_limit: Option<usize>,
 
-    pub shards: BTreeMap<String, Shard>,
-    pub users: BTreeMap<String, User>,
-
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,
+
+    pub shards: BTreeMap<String, Shard>,
+    pub users: BTreeMap<String, User>,
     // Note, don't put simple fields below these configs. There's a compatability issue with TOML that makes it
     // incompatible to have simple fields in TOML after complex objects. See
     // https://users.rust-lang.org/t/why-toml-to-string-get-error-valueaftertable/85903

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,4 +15,6 @@ pub enum Error {
     StatementTimeout,
     ShuttingDown,
     ParseBytesError(String),
+    AuthError(String),
+    AuthPassthroughError(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth_passthrough;
 pub mod config;
 pub mod constants;
 pub mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 mod admin;
+mod auth_passthrough;
 mod client;
 mod config;
 mod constants;

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 /// Packets arrive to us through a channel from the main client and we send them to the server.
 use bb8::Pool;
 use bytes::{Bytes, BytesMut};
+use parking_lot::RwLock;
 
 use crate::config::{get_config, Address, Role, User};
 use crate::pool::{ClientServerMap, PoolIdentifier, ServerPool};
@@ -41,6 +42,7 @@ impl MirroredClient {
             self.database.as_str(),
             ClientServerMap::default(),
             Arc::new(PoolStats::new(identifier, cfg.clone())),
+            Arc::new(RwLock::new(None)),
         );
 
         Pool::builder()

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1110,6 +1110,9 @@ mod test {
             sharding_key_regex: None,
             shard_id_regex: None,
             regex_search_limit: 1000,
+            auth_query: None,
+            auth_query_password: None,
+            auth_query_user: None,
         };
         let mut qr = QueryRouter::new();
         assert_eq!(qr.active_role, None);
@@ -1171,6 +1174,9 @@ mod test {
             sharding_key_regex: Some(Regex::new(r"/\* sharding_key: (\d+) \*/").unwrap()),
             shard_id_regex: Some(Regex::new(r"/\* shard_id: (\d+) \*/").unwrap()),
             regex_search_limit: 1000,
+            auth_query: None,
+            auth_query_password: None,
+            auth_query_user: None,
         };
         let mut qr = QueryRouter::new();
         qr.update_pool_settings(pool_settings.clone());

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -36,6 +36,15 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_INITDB_ARGS: --auth-local=scram-sha-256 --auth-host=scram-sha-256 --auth=scram-sha-256
     command: ["postgres", "-p", "9432", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "pg_stat_statements.max=100000"]
+  pg5:
+    image: postgres:14
+    network_mode: "service:main"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_INITDB_ARGS: --auth-local=md5 --auth-host=md5 --auth=md5
+    command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-p", "10432"]
   main:
     build: .
     command: ["bash", "/app/tests/docker/run.sh"]

--- a/tests/ruby/auth_query_spec.rb
+++ b/tests/ruby/auth_query_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require_relative 'helpers/auth_query_helper'
+
+describe "Auth Query" do
+  let(:configured_instances) {[5432, 10432]}
+  let(:config_user) { { 'username' => 'sharding_user', 'password' => 'sharding_user' } }
+  let(:pg_user) { { 'username' => 'sharding_user', 'password' => 'sharding_user' } }
+  let(:processes) { Helpers::AuthQuery.single_shard_auth_query(pool_name: "sharded_db", pg_user: pg_user, config_user: config_user, extra_conf: config, wait_until_ready: wait_until_ready ) }
+  let(:config) { {} }
+  let(:wait_until_ready) { true }
+
+  after do
+    unless @failing_process
+      processes.all_databases.map(&:reset)
+      processes.pgcat.shutdown
+    end
+    @failing_process = false
+  end
+
+  context "when auth_query is not configured" do
+    context 'and cleartext passwords are set' do
+      it "uses local passwords" do
+        conn = PG.connect(processes.pgcat.connection_string("sharded_db", config_user['username'], config_user['password']))
+
+        expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+      end
+    end
+
+    context 'and cleartext passwords are not set' do
+      let(:config_user) { { 'username' => 'sharding_user' } }
+
+      it "does not start because it is not possible to authenticate" do
+        @failing_process = true
+        expect { processes.pgcat }.to raise_error(StandardError, /You have to specify a user password for every pool if auth_query is not specified/)
+      end
+    end
+  end
+
+  context 'when auth_query is configured' do
+    context 'with global configuration' do
+      around(:example) do |example|
+
+        # Set up auth query
+        Helpers::AuthQuery.set_up_auth_query_for_user(
+          user: 'md5_auth_user',
+          password: 'secret'
+        );
+
+        example.run
+
+        # Drop auth query support
+        Helpers::AuthQuery.tear_down_auth_query_for_user(
+          user: 'md5_auth_user',
+          password: 'secret'
+        );
+      end
+
+      context 'with correct global parameters' do
+        let(:config) { { 'general' => { 'auth_query' => "SELECT * FROM public.user_lookup('$1');", 'auth_query_user' => 'md5_auth_user', 'auth_query_password' => 'secret' } } }
+        context 'and with cleartext passwords set' do
+          it 'it uses local passwords' do
+            conn = PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username'], pg_user['password']))
+            expect(conn.exec("SELECT 1 + 2")).not_to be_nil
+          end
+        end
+
+        context 'and with cleartext passwords not set' do
+          let(:config_user) { { 'username' => 'sharding_user', 'password' => 'sharding_user' } }
+
+          it 'it uses obtained passwords' do
+            connection_string = processes.pgcat.connection_string("sharded_db", pg_user['username'], pg_user['password'])
+            conn = PG.connect(connection_string)
+            expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+          end
+
+          it 'allows passwords to be changed without closing existing connections' do
+            pgconn = PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username']))
+            expect(pgconn.exec("SELECT 1 + 2")).not_to be_nil
+            Helpers::AuthQuery.exec_in_instances(query: "ALTER USER #{pg_user['username']} WITH ENCRYPTED PASSWORD 'secret2';")
+            expect(pgconn.exec("SELECT 1 + 4")).not_to be_nil
+            Helpers::AuthQuery.exec_in_instances(query: "ALTER USER #{pg_user['username']} WITH ENCRYPTED PASSWORD '#{pg_user['password']}';")
+          end
+
+          it 'allows passwords to be changed and that new password is needed when reconnecting' do
+            pgconn = PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username']))
+            expect(pgconn.exec("SELECT 1 + 2")).not_to be_nil
+            Helpers::AuthQuery.exec_in_instances(query: "ALTER USER #{pg_user['username']} WITH ENCRYPTED PASSWORD 'secret2';")
+            newconn = PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username'], 'secret2'))
+            expect(newconn.exec("SELECT 1 + 2")).not_to be_nil
+            Helpers::AuthQuery.exec_in_instances(query: "ALTER USER #{pg_user['username']} WITH ENCRYPTED PASSWORD '#{pg_user['password']}';")
+          end
+        end
+      end
+
+      context 'with wrong parameters' do
+        let(:config) { { 'general' => { 'auth_query' => 'SELECT 1', 'auth_query_user' => 'wrong_user', 'auth_query_password' => 'wrong' } } }
+
+        context 'and with clear text passwords set' do
+          it "it uses local passwords" do
+            conn = PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username'], pg_user['password']))
+
+            expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+          end
+        end
+
+        context 'and with cleartext passwords not set' do
+          let(:config_user) { { 'username' => 'sharding_user' } }
+          it "it fails to start as it cannot authenticate against servers" do
+            @failing_process = true
+            expect { PG.connect(processes.pgcat.connection_string("sharded_db", pg_user['username'], pg_user['password'])) }.to raise_error(StandardError, /Error trying to obtain password from auth_query/ )
+          end
+
+          context 'and we fix the issue and reload' do
+            let(:wait_until_ready) { false }
+
+            it 'fails in the beginning but starts working after reloading config' do
+              connection_string = processes.pgcat.connection_string("sharded_db", pg_user['username'], pg_user['password'])
+              while !(processes.pgcat.logs =~ /Waiting for clients/) do
+                sleep 0.5
+              end
+
+              expect { PG.connect(connection_string)}.to raise_error(PG::ConnectionBad)
+              expect(processes.pgcat.logs).to match(/Error trying to obtain password from auth_query/)
+
+              current_config = processes.pgcat.current_config
+              config = { 'general' => { 'auth_query' => "SELECT * FROM public.user_lookup('$1');", 'auth_query_user' => 'md5_auth_user', 'auth_query_password' => 'secret' } }
+              processes.pgcat.update_config(current_config.deep_merge(config))
+              processes.pgcat.reload_config
+
+              conn = nil
+              expect { conn = PG.connect(connection_string)}.not_to raise_error
+              expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+            end
+          end
+        end
+      end
+    end
+
+    context 'with per pool configuration' do
+      around(:example) do |example|
+
+        # Set up auth query
+        Helpers::AuthQuery.set_up_auth_query_for_user(
+          user: 'md5_auth_user',
+          password: 'secret'
+        );
+
+        Helpers::AuthQuery.set_up_auth_query_for_user(
+          user: 'md5_auth_user1',
+          password: 'secret',
+          database: 'shard1'
+        );
+
+        example.run
+
+        # Tear down auth query
+        Helpers::AuthQuery.tear_down_auth_query_for_user(
+          user: 'md5_auth_user',
+          password: 'secret'
+        );
+
+        Helpers::AuthQuery.tear_down_auth_query_for_user(
+          user: 'md5_auth_user1',
+          password: 'secret',
+          database: 'shard1'
+        );
+      end
+
+      context 'with correct parameters' do
+        let(:processes) { Helpers::AuthQuery.two_pools_auth_query(pool_names: ["sharded_db0", "sharded_db1"], pg_user: pg_user, config_user: config_user, extra_conf: config ) }
+        let(:config) {
+          { 'pools' =>
+            {
+              'sharded_db0' => {
+                'auth_query' => "SELECT * FROM public.user_lookup('$1');",
+                'auth_query_user' => 'md5_auth_user',
+                'auth_query_password' => 'secret'
+              },
+              'sharded_db1' => {
+                'auth_query' => "SELECT * FROM public.user_lookup('$1');",
+                'auth_query_user' => 'md5_auth_user1',
+                'auth_query_password' => 'secret'
+              },
+            }
+          }
+        } 
+
+        context 'and with cleartext passwords set' do
+          it 'it uses local passwords' do
+            conn = PG.connect(processes.pgcat.connection_string("sharded_db0", pg_user['username'], pg_user['password']))
+            expect(conn.exec("SELECT 1 + 2")).not_to be_nil
+            conn = PG.connect(processes.pgcat.connection_string("sharded_db1", pg_user['username'], pg_user['password']))
+            expect(conn.exec("SELECT 1 + 2")).not_to be_nil
+          end
+        end
+
+        context 'and with cleartext passwords not set' do
+          let(:config_user) { { 'username' => 'sharding_user' } }
+
+          it 'it uses obtained passwords' do
+            connection_string = processes.pgcat.connection_string("sharded_db0", pg_user['username'], pg_user['password'])
+            conn = PG.connect(connection_string)
+            expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+            connection_string = processes.pgcat.connection_string("sharded_db1", pg_user['username'], pg_user['password'])
+            conn = PG.connect(connection_string)
+            expect(conn.async_exec("SELECT 1 + 2")).not_to be_nil
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/tests/ruby/helpers/auth_query_helper.rb
+++ b/tests/ruby/helpers/auth_query_helper.rb
@@ -1,0 +1,173 @@
+module Helpers
+  module AuthQuery
+    def self.single_shard_auth_query(
+          pg_user:,
+          config_user:,
+          pool_name:,
+          extra_conf: {},
+          log_level: 'debug',
+          wait_until_ready: true
+        )
+
+      user = {
+        "pool_size" => 10,
+        "statement_timeout" => 0,
+      }
+
+      pgcat = PgcatProcess.new(log_level)
+      pgcat_cfg = pgcat.current_config.deep_merge(extra_conf)
+
+      primary  = PgInstance.new(5432,  pg_user["username"], pg_user["password"], "shard0")
+      replica  = PgInstance.new(10432, pg_user["username"], pg_user["password"], "shard0")
+
+      # Main proxy configs
+      pgcat_cfg["pools"] = {
+        "#{pool_name}" => {
+          "default_role" => "any",
+          "pool_mode" => "transaction",
+          "load_balancing_mode" => "random",
+          "primary_reads_enabled" => false,
+          "query_parser_enabled" => false,
+          "sharding_function" => "pg_bigint_hash",
+          "shards" => {
+            "0" => {
+              "database" => "shard0",
+              "servers" => [
+                ["localhost", primary.port.to_s, "primary"],
+                ["localhost", replica.port.to_s, "replica"],
+              ]
+            },
+          },
+          "users" => { "0" => user.merge(config_user) }
+        }
+      }
+      pgcat_cfg["general"]["port"] = pgcat.port
+      pgcat.update_config(pgcat_cfg)
+      pgcat.start
+      
+      pgcat.wait_until_ready(
+        pgcat.connection_string(
+          "sharded_db",
+          pg_user['username'],
+          pg_user['password']
+        )
+      ) if wait_until_ready
+
+      OpenStruct.new.tap do |struct|
+        struct.pgcat = pgcat
+        struct.primary = primary
+        struct.replicas = [replica]
+        struct.all_databases = [primary]
+      end
+    end
+
+    def self.two_pools_auth_query(
+          pg_user:,
+          config_user:,
+          pool_names:,
+          extra_conf: {},
+          log_level: 'debug'
+        )
+
+      user = {
+        "pool_size" => 10,
+        "statement_timeout" => 0,
+      }
+
+      pgcat = PgcatProcess.new(log_level)
+      pgcat_cfg = pgcat.current_config
+
+      primary  = PgInstance.new(5432,  pg_user["username"], pg_user["password"], "shard0")
+      replica  = PgInstance.new(10432, pg_user["username"], pg_user["password"], "shard0")
+
+      pool_template = Proc.new do |database|
+        {
+          "default_role" => "any",
+          "pool_mode" => "transaction",
+          "load_balancing_mode" => "random",
+          "primary_reads_enabled" => false,
+          "query_parser_enabled" => false,
+          "sharding_function" => "pg_bigint_hash",
+          "shards" => {
+            "0" => {
+              "database" => database,
+              "servers" => [
+                ["localhost", primary.port.to_s, "primary"],
+                ["localhost", replica.port.to_s, "replica"],
+              ]
+            },
+          },
+          "users" => { "0" => user.merge(config_user) }
+        }                                  
+      end
+      # Main proxy configs
+      pgcat_cfg["pools"] = {
+        "#{pool_names[0]}" => pool_template.call("shard0"),
+        "#{pool_names[1]}" => pool_template.call("shard1")
+      }
+
+      pgcat_cfg["general"]["port"] = pgcat.port
+      pgcat.update_config(pgcat_cfg.deep_merge(extra_conf))
+      pgcat.start
+      
+      pgcat.wait_until_ready(pgcat.connection_string("sharded_db0", pg_user['username'], pg_user['password']))
+
+      OpenStruct.new.tap do |struct|
+        struct.pgcat = pgcat
+        struct.primary = primary
+        struct.replicas = [replica]
+        struct.all_databases = [primary]
+      end
+    end
+
+    def self.create_query_auth_function(user)
+      return <<-SQL
+CREATE OR REPLACE FUNCTION public.user_lookup(in i_username text, out uname text, out phash text)
+RETURNS record AS $$
+BEGIN
+    SELECT usename, passwd FROM pg_catalog.pg_shadow
+    WHERE usename = i_username INTO uname, phash;
+    RETURN;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION public.user_lookup(text) TO #{user};
+SQL
+    end
+
+    def self.exec_in_instances(query:, instance_ports: [ 5432, 10432 ], database: 'postgres', user: 'postgres', password: 'postgres')
+      instance_ports.each do |port|
+        c = PG.connect("postgres://#{user}:#{password}@localhost:#{port}/#{database}")
+        c.exec(query)
+        c.close
+      end
+    end
+
+    def self.set_up_auth_query_for_user(user:, password:, instance_ports: [ 5432, 10432 ], database: 'shard0' )
+      instance_ports.each do |port|
+        connection = PG.connect("postgres://postgres:postgres@localhost:#{port}/#{database}")
+        connection.exec(self.drop_query_auth_function(user)) rescue PG::UndefinedFunction
+        connection.exec("DROP ROLE #{user}") rescue PG::UndefinedObject
+        connection.exec("CREATE ROLE #{user} ENCRYPTED PASSWORD '#{password}' LOGIN;")
+        connection.exec(self.create_query_auth_function(user))
+        connection.close
+      end
+    end
+
+    def self.tear_down_auth_query_for_user(user:, password:, instance_ports: [ 5432, 10432 ], database: 'shard0' )
+      instance_ports.each do |port|
+        connection = PG.connect("postgres://postgres:postgres@localhost:#{port}/#{database}")
+        connection.exec(self.drop_query_auth_function(user)) rescue PG::UndefinedFunction
+        connection.exec("DROP ROLE #{user}")
+        connection.close
+      end
+    end
+
+    def self.drop_query_auth_function(user)
+      return <<-SQL
+REVOKE ALL ON FUNCTION public.user_lookup(text) FROM public, #{user};
+DROP FUNCTION public.user_lookup(in i_username text, out uname text, out phash text);
+SQL
+    end
+  end
+end

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -3,6 +3,13 @@ require 'ostruct'
 require_relative 'pgcat_process'
 require_relative 'pg_instance'
 
+class ::Hash
+    def deep_merge(second)
+        merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+        self.merge(second, &merger)
+    end
+end
+
 module Helpers
   module Pgcat
     def self.three_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info")


### PR DESCRIPTION
# Auth passthrough (auth_query) feature

**EDITED**

Add auth passthough (auth_query)

Adds a feature that allows setting auth passthrough for md5 auth.

## Configuration:

It adds 3 new (general and pool) config parameters:

- `auth_query`: An string containing a query that will be executed on boot
to obtain the hash of a given user. This query have to use a placeholder `$1`,
so pgcat can replace it with the user its trying to fetch the hash from.
- `auth_query_user`: The user to use for connecting to the server and executing the
auth_query.
- `auth_query_password`: The password to use for connecting to the server and executing the
auth_query.

The configuration can be done either on the general config (so pools share them) or in a per-pool basis.

## Behavior

The behavior is, at boot time, when validating server connections, a hash is fetched per server
and stored in the pool. When new server connections are created, and no cleartext password is specified,
the obtained hash is used for creating them, if the hash could not be obtained for whatever reason, it retries
it.

When client authentication is tried, it uses cleartext passwords if specified, it not, it checks whether
we have query_auth set up, if so, it tries to use the obtained hash for making client auth. If there is no
hash (we could not obtain one when validating the connection), a new fetch is tried.

Once we have a hash, we authenticate using it against whathever the client has sent us, if there is a failure
we refetch the hash and retry auth (so password changes can be done).

The idea with this 'retrial' mechanism is to make it fault tolerant, so if for whatever reason hash could not be
obtained during connection validation, or the password has change, we can still connect later.

## Testing

This is currently tested using ruby tests:

![image](https://user-images.githubusercontent.com/83188/223080407-3edb9f85-e12b-45b7-94b0-87501230dde4.png)


## Considerations

- A new crate is added to deal with postgres protocol parsing, I first did it myself and didn't like the result so thought, why reinventing the wheel?
- ~~Currently hash refresh is not done when reloading and no pool have changed~~.
- No documentation is yet written, I want to first discuss about the change and will write later if we agree on the merge.
- This fixes (https://github.com/levkk/pgcat/issues/253)
