### PR TITLE
Zero downtime password rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ PostgreSQL pooler and proxy (like PgBouncer) with support for sharding, load bal
 | Automatic sharding | **Experimental** | PgCat can parse queries, detect sharding keys automatically, and route queries to the correct shard. |
 | Mirroring | **Experimental** | Mirror queries between multiple databases in order to test servers with realistic production traffic. |
 | Auth passthrough | **Experimental** | MD5 password authentication can be configured to use an `auth_query` so no cleartext passwords are needed in the config file.                         |
+| Password rotation | **Experimental** | Allows to rotate passwords without downtime or using third-party tools to manage Postgres authentication. |
 
 
 ## Status
@@ -243,6 +244,12 @@ The config can be reloaded by sending a `kill -s SIGHUP` to the process or by qu
 ### Mirroring
 
 Mirroring allows to route queries to multiple databases at the same time. This is useful for prewarning replicas before placing them into the active configuration, or for testing different versions of Postgres with live traffic.
+
+### Password rotation
+
+Password rotation allows to specify multiple passwords for a user, so they can connect to PgCat with multiple credentials. This allows distributed applications to change their configuration (connection strings) gradually and for PgCat to monitor their progression in admin statistics. Once the new secret is deployed everywhere, the old one can be removed from PgCat.
+
+This also decouples server passwords from client passwords, allowing to change one without necessarily changing the other.
 
 ## License
 

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -58,9 +58,9 @@ tcp_keepalives_count = 5
 tcp_keepalives_interval = 5
 
 # Path to TLS Certficate file to use for TLS connections
-tls_certificate = ".circleci/server.cert"
+# tls_certificate = ".circleci/server.cert"
 # Path to TLS private key file to use for TLS connections
-tls_private_key = ".circleci/server.key"
+# tls_private_key = ".circleci/server.key"
 
 # User name to access the virtual administrative database (pgbouncer or pgcat)
 # Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DATABASES`, etc..

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -58,9 +58,9 @@ tcp_keepalives_count = 5
 tcp_keepalives_interval = 5
 
 # Path to TLS Certficate file to use for TLS connections
-# tls_certificate = "server.cert"
+tls_certificate = ".circleci/server.cert"
 # Path to TLS private key file to use for TLS connections
-# tls_private_key = "server.key"
+tls_private_key = ".circleci/server.key"
 
 # User name to access the virtual administrative database (pgbouncer or pgcat)
 # Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DATABASES`, etc..
@@ -129,6 +129,10 @@ connect_timeout = 3000
 username = "sharding_user"
 # Postgresql password
 password = "sharding_user"
+
+# Passwords the client can use to connect. Useful for password rotations.
+secrets = [ "secret_one", "secret_two" ]
+
 # Maximum number of server connections that can be established for this user
 # The maximum number of connection from a single Pgcat process to any database in the cluster
 # is the sum of pool_size across all users.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -780,7 +780,7 @@ where
         let database = parts[0];
         let user = parts[1];
 
-        match get_pool(database, user) {
+        match get_pool(database, user, None) {
             Some(pool) => {
                 pool.pause();
 
@@ -827,7 +827,7 @@ where
         let database = parts[0];
         let user = parts[1];
 
-        match get_pool(database, user) {
+        match get_pool(database, user, None) {
             Some(pool) => {
                 pool.resume();
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,382 @@
+//! Module implementing various client authentication mechanisms.
+//!
+//! Currently supported: plain (via TLS), md5 (via TLS and plain text connection).
+
+use crate::errors::Error;
+use crate::tokio::io::AsyncReadExt;
+use crate::{
+    config::get_config,
+    messages::{error_response, md5_hash_password, write_all, wrong_password, md5_hash_second_pass},
+    pool::{get_pool, ConnectionPool},
+    auth_passthrough::AuthPassthrough,
+};
+use bytes::{BufMut, BytesMut};
+use log::debug;
+
+async fn refetch_auth_hash<S>(pool: &ConnectionPool, stream: &mut S, username: &str, pool_name: &str) -> Result<String, Error>
+where S: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send
+{
+    let address = pool.address(0, 0);
+    if let Some(apt) = AuthPassthrough::from_pool_settings(&pool.settings) {
+        let hash = apt.fetch_hash(address).await?;
+
+        return Ok(hash);
+    }
+
+    error_response(
+        stream,
+        &format!(
+            "No password set and auth passthrough failed for database: {}, user: {}",
+            pool_name, username
+        ),
+    ).await?;
+
+    Err(Error::ClientError(format!(
+        "Could not obtain hash for {{ username: {:?}, database: {:?} }}. Auth passthrough not enabled.",
+        address.username, address.database
+    )))
+}
+
+/// Read 'p' message from client.
+async fn response<R>(stream: &mut R) -> Result<Vec<u8>, Error>
+where
+    R: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
+{
+    let code = match stream.read_u8().await {
+        Ok(code) => code,
+        Err(_) => {
+            return Err(Error::SocketError(
+                "Error reading password code from client".to_string(),
+            ))
+        }
+    };
+
+    if code as char != 'p' {
+        return Err(Error::SocketError(format!("Expected p, got {}", code)));
+    }
+
+    let len = match stream.read_i32().await {
+        Ok(len) => len,
+        Err(_) => {
+            return Err(Error::SocketError(
+                "Error reading password length from client".to_string(),
+            ))
+        }
+    };
+
+    let mut response = vec![0; (len - 4) as usize];
+
+    match stream.read_exact(&mut response).await {
+        Ok(_) => (),
+        Err(_) => {
+            return Err(Error::SocketError(
+                "Error reading password from client".to_string(),
+            ))
+        }
+    };
+
+    Ok(response.to_vec())
+}
+
+/// Make sure the pool we authenticated to has at least one server connection
+/// that can serve our request.
+async fn validate_pool<W>(
+    stream: &mut W,
+    mut pool: ConnectionPool,
+    username: &str,
+    pool_name: &str,
+) -> Result<(), Error>
+where
+    W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+{
+    if !pool.validated() {
+        match pool.validate().await {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                error_response(
+                    stream,
+                    &format!(
+                        "Pool down for database: {:?}, user: {:?}",
+                        pool_name, username,
+                    ),
+                )
+                .await?;
+
+                Err(Error::ClientError(format!("Pool down: {:?}", err)))
+            }
+        }
+    } else {
+        Ok(())
+    }
+}
+
+/// Clear text authentication.
+///
+/// The client will send the password in plain text over the wire.
+/// To protect against obvious security issues, this is only used over TLS.
+///
+/// Clear text authentication is used to support zero-downtime password rotation.
+/// It allows the client to use multiple passwords when talking to the PgCat
+/// while the password is being rotated across multiple app instances.
+pub struct ClearText {
+    username: String,
+    pool_name: String,
+    application_name: String,
+}
+
+impl ClearText {
+    /// Create a new ClearText authentication mechanism.
+    pub fn new(username: &str, pool_name: &str, application_name: &str) -> ClearText {
+        ClearText {
+            username: username.to_string(),
+            pool_name: pool_name.to_string(),
+            application_name: application_name.to_string(),
+        }
+    }
+
+    /// Issue 'R' clear text challenge to client.
+    pub async fn challenge<W>(&self, stream: &mut W) -> Result<(), Error>
+    where
+        W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+    {
+        debug!("Sending plain challenge");
+
+        let mut msg = BytesMut::new();
+        msg.put_u8(b'R');
+        msg.put_i32(8);
+        msg.put_i32(3); // Clear text
+
+        write_all(stream, msg).await
+    }
+
+    /// Authenticate client with server password or secret.
+    pub async fn authenticate<R, W>(
+        &self,
+        read: &mut R,
+        write: &mut W,
+    ) -> Result<Option<String>, Error>
+    where
+        R: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
+        W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+    {
+        let response = response(read).await?;
+
+        let secret = String::from_utf8_lossy(&response[0..response.len() - 1]).to_string();
+
+        match get_pool(&self.pool_name, &self.username, Some(secret.clone())) {
+            None => match get_pool(&self.pool_name, &self.username, None) {
+                Some(pool) => {
+                    match pool.settings.user.password {
+                        Some(ref password) => {
+                            if password != &secret {
+                                wrong_password(write, &self.username).await?;
+                                Err(Error::ClientError(format!(
+                                        "Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                                        self.username, self.pool_name, self.application_name
+                                )))
+                            }
+                            else {
+                                validate_pool(write, pool, &self.username, &self.pool_name).await?;
+
+                                Ok(None)
+                            }
+                        }
+
+                        None => {
+                            // Server is storing hashes, we can't query it for the plain text password.
+                            error_response(
+                                write,
+                                &format!(
+                                    "No server password configured for database: {:?}, user: {:?}",
+                                    self.pool_name, self.username
+                                ),
+                            )
+                            .await?;
+
+                            Err(Error::ClientError(format!(
+                                "No server password configured for {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                                self.username, self.pool_name, self.application_name
+                            )))
+                        }
+                    }
+                }
+
+                None => {
+                    error_response(
+                        write,
+                        &format!(
+                            "No pool configured for database: {:?}, user: {:?}",
+                            self.pool_name, self.username
+                        ),
+                    )
+                    .await?;
+
+                    Err(Error::ClientError(format!(
+                            "Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                            self.username, self.pool_name, self.application_name
+                        )))
+                }
+            },
+            Some(pool) => {
+                validate_pool(write, pool, &self.username, &self.pool_name).await?;
+                Ok(Some(secret))
+            }
+        }
+    }
+}
+
+/// MD5 hash authentication.
+///
+/// Deprecated, but widely used everywhere, and currently required for poolers
+/// to authencticate clients without involving Postgres.
+///
+/// Admin clients are required to use MD5.
+pub struct Md5 {
+    username: String,
+    pool_name: String,
+    application_name: String,
+    salt: [u8; 4],
+    admin: bool,
+}
+
+impl Md5 {
+    pub fn new(username: &str, pool_name: &str, application_name: &str, admin: bool) -> Md5 {
+        let salt: [u8; 4] = [
+            rand::random(),
+            rand::random(),
+            rand::random(),
+            rand::random(),
+        ];
+
+        Md5 {
+            username: username.to_string(),
+            pool_name: pool_name.to_string(),
+            application_name: application_name.to_string(),
+            salt,
+            admin,
+        }
+    }
+
+    /// Issue a 'R' MD5 challenge to the client.
+    pub async fn challenge<W>(&self, stream: &mut W) -> Result<(), Error>
+    where
+        W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+    {
+        let mut res = BytesMut::new();
+        res.put_u8(b'R');
+        res.put_i32(12);
+        res.put_i32(5); // MD5
+        res.put_slice(&self.salt[..]);
+
+        write_all(stream, res).await
+    }
+
+    /// Authenticate client with MD5. This is used for both admin and normal users.
+    pub async fn authenticate<R, W>(&self, read: &mut R, write: &mut W) -> Result<(), Error>
+    where
+        R: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
+        W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+    {
+        let password_hash = response(read).await?;
+
+        if self.admin {
+            let config = get_config();
+
+            // Compare server and client hashes.
+            let our_hash = md5_hash_password(
+                &config.general.admin_username,
+                &config.general.admin_password,
+                &self.salt,
+            );
+
+            if our_hash != password_hash {
+                wrong_password(write, &self.username).await?;
+                Err(Error::ClientError(format!(
+                    "Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                    self.username, self.pool_name, self.application_name
+                )))
+            } else {
+                Ok(())
+            }
+        } else {
+            match get_pool(&self.pool_name, &self.username, None) {
+                Some(pool) => {
+                    match &pool.settings.user.password {
+                        Some(ref password) => {
+                            let our_hash = md5_hash_password(&self.username, password, &self.salt);
+
+                             if our_hash != password_hash {
+                                wrong_password(write, &self.username).await?;
+
+                                Err(Error::ClientError(format!(
+                                    "Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                                    self.username, self.pool_name, self.application_name
+                                )))
+                            } else {
+                                validate_pool(write, pool, &self.username, &self.pool_name).await?;
+                                Ok(())
+                            }
+                        }
+
+                        None => {
+                            // Fetch hash from server
+                            let hash = (*pool.auth_hash.read()).clone();
+
+                            let hash = match hash {
+                                Some(hash) => hash.to_string(),
+                                None => refetch_auth_hash(&pool, write, &self.username, &self.pool_name).await?,
+                            };
+
+                            let our_hash = md5_hash_second_pass(&hash, &self.salt);
+
+                            // Compare hashes
+                            if our_hash != password_hash {
+                                // Server hash maybe changed
+                                let hash = refetch_auth_hash(&pool, write, &self.username, &self.pool_name).await?;
+                                let our_hash = md5_hash_second_pass(&hash, &self.salt);
+
+                                if our_hash != password_hash {
+                                    wrong_password(write, &self.username).await?;
+
+                                    Err(Error::ClientError(format!(
+                                        "Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                                        self.username, self.pool_name, self.application_name
+                                    )))
+                                } else {
+                                    (*pool.auth_hash.write()) = Some(hash);
+
+                                    validate_pool(write, pool.clone(), &self.username, &self.pool_name).await?;
+
+                                    Ok(())
+                                }
+                            } else {
+                                wrong_password(write, &self.username).await?;
+
+                                Err(Error::ClientError(format!(
+                                    "Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                                    self.username, self.pool_name, self.application_name
+                                )))
+                            }
+                        }
+                    }
+                }
+
+                None => {
+                    error_response(
+                        write,
+                        &format!(
+                            "No pool configured for database: {:?}, user: {:?}",
+                            self.pool_name, self.username
+                        ),
+                    )
+                    .await?;
+
+                    return Err(Error::ClientError(format!(
+                        "Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}",
+                        self.username, self.pool_name, self.application_name
+                    )));
+                }
+            }
+        }
+    }
+}

--- a/src/auth_passthrough.rs
+++ b/src/auth_passthrough.rs
@@ -73,6 +73,7 @@ impl AuthPassthrough {
             password: Some(self.password.clone()),
             pool_size: 1,
             statement_timeout: 0,
+            secrets: None,
         };
 
         let user = &address.username;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 /// Parse the configuration file.
 use arc_swap::ArcSwap;
-use log::{error, info};
+use log::{error, info, warn};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
@@ -186,6 +186,19 @@ pub struct User {
 
 impl User {
     fn validate(&self) -> Result<(), Error> {
+        match self.secrets {
+            Some(ref secrets) => {
+                for secret in secrets.iter() {
+                    if secret.len() < 16 {
+                        warn!(
+                            "[user: {}] Secret is too short (less than 16 characters)",
+                            self.username
+                        );
+                    }
+                }
+            }
+            None => (),
+        }
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,13 @@ pub struct User {
     pub pool_size: u32,
     #[serde(default)] // 0
     pub statement_timeout: u64,
+    pub secrets: Option<Vec<String>>,
+}
+
+impl User {
+    fn validate(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl Default for User {
@@ -190,6 +197,7 @@ impl Default for User {
             password: None,
             pool_size: 15,
             statement_timeout: 0,
+            secrets: None,
         }
     }
 }
@@ -508,6 +516,10 @@ impl Pool {
             None => None,
         };
 
+        for user in self.users.iter() {
+            user.1.validate()?;
+        }
+
         Ok(())
     }
 }
@@ -656,6 +668,11 @@ impl Config {
                 pool.auth_query_password = self.general.auth_query_password.clone();
             }
         }
+    }
+
+    /// Checks that we configured TLS.
+    pub fn tls_enabled(&self) -> bool {
+        self.general.tls_certificate.is_some() && self.general.tls_private_key.is_some()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,8 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 mod admin;
-mod auth_passthrough;
 mod auth;
+mod auth_passthrough;
 mod client;
 mod config;
 mod constants;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ use tokio::sync::broadcast;
 
 mod admin;
 mod auth_passthrough;
+mod auth;
 mod client;
 mod config;
 mod constants;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -46,29 +46,6 @@ where
     write_all(stream, auth_ok).await
 }
 
-/// Generate md5 password challenge.
-pub async fn md5_challenge<S>(stream: &mut S) -> Result<[u8; 4], Error>
-where
-    S: tokio::io::AsyncWrite + std::marker::Unpin,
-{
-    // let mut rng = rand::thread_rng();
-    let salt: [u8; 4] = [
-        rand::random(),
-        rand::random(),
-        rand::random(),
-        rand::random(),
-    ];
-
-    let mut res = BytesMut::new();
-    res.put_u8(b'R');
-    res.put_i32(12);
-    res.put_i32(5); // MD5
-    res.put_slice(&salt[..]);
-
-    write_all(stream, res).await?;
-    Ok(salt)
-}
-
 /// Give the client the process_id and secret we generated
 /// used in query cancellation.
 pub async fn backend_key_data<S>(

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -34,7 +34,7 @@ impl MirroredClient {
                 None => (default, default, crate::config::Pool::default()),
             };
 
-        let identifier = PoolIdentifier::new(&self.database, &self.user.username);
+        let identifier = PoolIdentifier::new(&self.database, &self.user.username, None);
 
         let manager = ServerPool::new(
             self.address.clone(),

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -218,11 +218,10 @@ impl ConnectionPool {
                         .collect::<Vec<Option<String>>>(),
                     None => vec![],
                 };
-                
+
                 secrets.push(None);
 
                 for secret in secrets {
-
                     let old_pool_ref = get_pool(pool_name, &user.username, secret.clone());
                     let identifier = PoolIdentifier::new(pool_name, &user.username, secret.clone());
 
@@ -362,7 +361,9 @@ impl ConnectionPool {
 
                             let pool = Pool::builder()
                                 .max_size(user.pool_size)
-                                .connection_timeout(std::time::Duration::from_millis(connect_timeout))
+                                .connection_timeout(std::time::Duration::from_millis(
+                                    connect_timeout,
+                                ))
                                 .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                                 .test_on_check_out(false)
                                 .build(manager)

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::config::Address;
-use crate::pool::get_all_pools;
+use crate::pool::{get_all_pools, PoolIdentifier};
 use crate::stats::{get_pool_stats, get_server_stats, ServerStats};
 
 struct MetricHelpType {
@@ -233,10 +233,10 @@ impl<Value: fmt::Display> PrometheusMetric<Value> {
         Self::from_name(&format!("stats_{}", name), value, labels)
     }
 
-    fn from_pool(pool: &(String, String), name: &str, value: u64) -> Option<PrometheusMetric<u64>> {
+    fn from_pool(pool: &PoolIdentifier, name: &str, value: u64) -> Option<PrometheusMetric<u64>> {
         let mut labels = HashMap::new();
-        labels.insert("pool", pool.0.clone());
-        labels.insert("user", pool.1.clone());
+        labels.insert("pool", pool.db.clone());
+        labels.insert("user", pool.user.clone());
 
         Self::from_name(&format!("pools_{}", name), value, labels)
     }
@@ -294,7 +294,7 @@ fn push_pool_stats(lines: &mut Vec<String>) {
             } else {
                 warn!(
                     "Metric {} not implemented for ({},{})",
-                    name, pool.0, pool.1
+                    name, pool.db, pool.user
                 );
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -22,7 +22,7 @@ pub use server::{ServerState, ServerStats};
 /// Convenience types for various stats
 type ClientStatesLookup = HashMap<i32, Arc<ClientStats>>;
 type ServerStatesLookup = HashMap<i32, Arc<ServerStats>>;
-type PoolStatsLookup = HashMap<(String, String), Arc<PoolStats>>;
+type PoolStatsLookup = HashMap<PoolIdentifier, Arc<PoolStats>>;
 
 /// Stats for individual client connections
 /// Used in SHOW CLIENTS.
@@ -83,9 +83,7 @@ impl Reporter {
 
     /// Register a pool with the stats system.
     fn pool_register(&self, identifier: PoolIdentifier, stats: Arc<PoolStats>) {
-        POOL_STATS
-            .write()
-            .insert((identifier.db, identifier.user), stats);
+        POOL_STATS.write().insert(identifier, stats);
     }
 }
 

--- a/src/stats/pool.rs
+++ b/src/stats/pool.rs
@@ -102,6 +102,13 @@ impl PoolStats {
         self.identifier.user.clone()
     }
 
+    pub fn redacted_secret(&self) -> String {
+        match self.identifier.secret {
+            Some(ref s) => format!("****{}", &s[s.len() - 4..]),
+            None => "<no secret>".to_string(),
+        }
+    }
+
     pub fn pool_mode(&self) -> PoolMode {
         self.config.pool_mode
     }

--- a/tests/ruby/auth_spec.rb
+++ b/tests/ruby/auth_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require_relative 'spec_helper'
+
+
+describe "Authentication" do
+  describe "multiple secrets configured" do
+    let(:secrets) { ["one_secret", "two_secret"] }
+    let(:processes) { Helpers::Pgcat.three_shard_setup("sharded_db", 5, pool_mode="transaction", lb_mode="random", log_level="info", secrets=["one_secret", "two_secret"]) }
+
+    after do
+      processes.all_databases.map(&:reset)
+      processes.pgcat.shutdown
+    end
+
+    it "can connect using all secrets and postgres password" do
+      secrets.push("sharding_user").each do |secret|
+        conn = PG.connect(processes.pgcat.connection_string("sharded_db", "sharding_user", password=secret))
+        conn.exec("SELECT current_user")
+      end
+    end
+  end
+
+  describe "no secrets configured" do
+    let(:secrets) { [] }
+    let(:processes) { Helpers::Pgcat.three_shard_setup("sharded_db", 5, pool_mode="transaction", lb_mode="random", log_level="info") }
+
+    after do
+      processes.all_databases.map(&:reset)
+      processes.pgcat.shutdown
+    end
+
+    it "can connect using only the password" do
+      conn = PG.connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+      conn.exec("SELECT current_user")
+
+      expect { PG.connect(processes.pgcat.connection_string("sharded_db", "sharding_user", password="secret_one")) }.to raise_error PG::ConnectionBad
+    end
+  end
+end

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -12,13 +12,17 @@ end
 
 module Helpers
   module Pgcat
-    def self.three_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info")
+    def self.three_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info", secrets=nil)
       user = {
         "password" => "sharding_user",
         "pool_size" => pool_size,
         "statement_timeout" => 0,
-        "username" => "sharding_user"
+        "username" => "sharding_user",
       }
+
+      if !secrets.nil?
+        user["secrets"] = secrets
+      end
 
       pgcat    = PgcatProcess.new(log_level)
       primary0 = PgInstance.new(5432, user["username"], user["password"], "shard0")
@@ -27,7 +31,7 @@ module Helpers
 
       pgcat_cfg = pgcat.current_config
       pgcat_cfg["pools"] = {
-        "#{pool_name}" => {
+        "#{pool_name}" =>  {
           "default_role" => "any",
           "pool_mode" => pool_mode,
           "load_balancing_mode" => lb_mode,
@@ -41,8 +45,14 @@ module Helpers
             "2" => { "database" => "shard2", "servers" => [["localhost", primary2.port.to_s, "primary"]] },
           },
           "users" => { "0" => user }
-        }
+        },
       }
+
+      if !secrets.nil?
+        pgcat_cfg["general"]["tls_certificate"] = "../../.circleci/server.cert"
+        pgcat_cfg["general"]["tls_private_key"] = "../../.circleci/server.key"
+      end
+
       pgcat.update_config(pgcat_cfg)
 
       pgcat.start

--- a/tests/ruby/helpers/pgcat_process.rb
+++ b/tests/ruby/helpers/pgcat_process.rb
@@ -112,10 +112,13 @@ class PgcatProcess
     "postgresql://#{username}:#{password}@0.0.0.0:#{@port}/pgcat"
   end
 
-  def connection_string(pool_name, username, password = nil)
+  def connection_string(pool_name, username, password=nil)
     cfg = current_config
     user_idx, user_obj = cfg["pools"][pool_name]["users"].detect { |k, user| user["username"] == username }
-    "postgresql://#{username}:#{password || user_obj["password"]}@0.0.0.0:#{@port}/#{pool_name}"
+
+    password = if password.nil? then user_obj["password"] else password end
+
+    "postgresql://#{username}:#{password}@0.0.0.0:#{@port}/#{pool_name}"
   end
 
   def example_connection_string


### PR DESCRIPTION
### Problem

Sometimes passwords leak. Also sometimes security teams want infrastructure teams to rotate passwords. With Postgres, that's impossible currently without taking down the application or using third-party tools like Vault. If one was to change the password today, all new connections will be denied, causing a production incident.

### Solution

This PR introduces the ability to use multiple passwords (called secrets) to connect to PgCat while one secret is being deprecated and replaced with the other. Each database <--> user <--> secret triplet gets their own connection pool (before, it was only database <--> user, like PgBouncer).

Creating separate pools is a good idea because it allows us to:

1. Separate clients with old password from clients with new password in admin, so we can track the progression of the password rotation
2. Forcibly disconnect clients that are using an old password by shutting down their pool.

### Implementation caveats

All Postgres authentication mechanisms except plain text obfuscate the secret (password) being used, so without knowing more, we need to test all configured passwords. Additionally, we can't (I think) come up with a unique pool identifier using a hashed password, since the hashing has to be deterministic, which defeats the purpose of password hashing (they are random, e.g. md5 creates a different hash every time because of random salt).

So, for this feature to work, we need to use plain text authentication. Of course that will set off all kinds of alarm flags with most people, since this method is not secure by itself (neither is MD5, but that's out of scope at the moment). So, we only allow this mechanism to work if PgCat is configured to use TLS connections. Using TLS and plain text passwords together is safe and used everywhere across the Internet today. If it's good enough for the banks, it's good enough for us.

Postgres docs on plain auth: https://www.postgresql.org/docs/15/auth-password.html

### Changes

#### pgcat.toml

Additional `secrets = [ "one", "two", "three" ]` option is added to `[users]` section. This configures multiple passwords (and pools) for the user. The `password` option is used to connect to Postgres.

#### admin db

An additional `secret` column is added (redacted) to differentiate pool statistics.

```
pgcat=> show users;
     name      |  pool_mode  |   secret    
---------------+-------------+-------------
 simple_user   | session     | <no secret>
 sharding_user | transaction | ****_one
 sharding_user | transaction | ****_two
 sharding_user | transaction | <no secret>
 other_user    | transaction | <no secret>
(5 rows)
```

```
pgcat=> show pools;
  database  |     user      |   secret    |  pool_mode  | cl_idle | cl_active | cl_waiting | cl_cancel_req | sv_active | sv_idle | sv_used | sv_tested | sv_login | maxwait | maxwait_us 
------------+---------------+-------------+-------------+---------+-----------+------------+---------------+-----------+---------+---------+-----------+----------+---------+------------
 sharded_db | sharding_user | ****_two    | transaction |       0 |         0 |          0 |             0 |         0 |       6 |       0 |         0 |        0 |       0 |          0
 sharded_db | sharding_user | <no secret> | transaction |       0 |         0 |          0 |             0 |         0 |       6 |       0 |         0 |        0 |       0 |          0
 sharded_db | sharding_user | ****_one    | transaction |       0 |         0 |          0 |             0 |         0 |       6 |       0 |         0 |        0 |       0 |          0
 sharded_db | other_user    | <no secret> | transaction |       0 |         0 |          0 |             0 |         0 |       6 |       0 |         0 |        0 |       0 |          0
 simple_db  | simple_user   | <no secret> | session     |       0 |         0 |          0 |             0 |         0 |       2 |       0 |         0 |        0 |       0 |          0
(5 rows)
```

### Ops

To use this feature:

1. Add new secret to `secrets` for the user, reload the config.
2. Change the password in all apps and redeploy.
3. Wait for deploy to finish, remove old secret from `secrets`, reload the config.
4. In quick succession: a) `ALTER ROLE ...` in Postgres to change the password, b) change `password` in config and reload.

Step 4 can be done with 0 errors if `min_size` for the pool is set to `max_size`, opening all connections in advance. This ensures no new connection to Postgres is made during step 4. Existing connections using the old password are not affected by `ALTER ROLE`.