### PR TITLE
feat: set keepalive for pgcat server itself

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,4 +1,4 @@
-# PgCat Configurations 
+# PgCat Configurations
 ## `general` Section
 
 ### host
@@ -127,7 +127,7 @@ path: general.tcp_keepalives_idle
 default: 5
 ```
 
-Number of seconds of connection idleness to wait before sending a keepalive packet to the server.
+Number of seconds of connection idleness to wait before sending a keepalive packet to the server and client.
 
 ### tcp_keepalives_count
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ mod stats;
 mod tls;
 
 use crate::config::{get_config, reload_config, VERSION};
+use crate::messages::configure_socket;
 use crate::pool::{ClientServerMap, ConnectionPool};
 use crate::prometheus::start_metric_server;
 use crate::stats::{Collector, Reporter, REPORTER};
@@ -288,6 +289,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let client_server_map = client_server_map.clone();
 
                     let tls_certificate = get_config().general.tls_certificate.clone();
+
+                    configure_socket(&socket);
 
                     tokio::task::spawn(async move {
                         let start = chrono::offset::Utc::now().naive_utc();


### PR DESCRIPTION
ref https://github.com/postgresml/pgcat/issues/400

This is a solution. I resolved the intermittent client EOF issue on AWS NLB by apply this configuration to the pgcat server itself socket.
