### PR TITLE
Plugins!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,6 +913,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_derive",
+ "serde_json",
  "sha-1",
  "sha2",
  "socket2",
@@ -1175,6 +1176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1208,9 @@ name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1211,6 +1221,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.9",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pgcat"
-version = "1.0.1"
+version = "1.0.2-alpha1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1297,6 +1297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dc4d4b6207ca8a3434fc587db0a8016130a574dbcdbfb93d7f7b5bc5b211a"
 dependencies = [
  "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fe75cb4a364c7f7ae06c7dbbc8d84bddd85d6cdf9975963c3935bc1991761e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8"
 chrono = "0.4"
 sha-1 = "0.10"
 toml = "0.7"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 regex = "1"
 num_cpus = "1"
@@ -44,6 +44,7 @@ webpki-roots = "0.23"
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
 trust-dns-resolver = "0.22.0"
 tokio-test = "0.4.2"
+serde_json = "1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "1.0.1"
+version = "1.0.2-alpha1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -19,7 +19,7 @@ serde_derive = "1"
 regex = "1"
 num_cpus = "1"
 once_cell = "1"
-sqlparser = "0.33.0"
+sqlparser = {version = "0.33", features = ["visitor"] }
 log = "0.4"
 arc-swap = "1"
 env_logger = "0.10"

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -77,6 +77,9 @@ admin_username = "admin_user"
 # Password to access the virtual administrative database
 admin_password = "admin_pass"
 
+# Plugins!!
+# plugins = ["pg_table_access", "intercept"]
+
 # pool configs are structured as pool.<pool_name>
 # the pool_name is what clients use as database name when connecting.
 # For a pool named `sharded_db`, clients access that pool using connection string like

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -78,7 +78,7 @@ admin_username = "admin_user"
 admin_password = "admin_pass"
 
 # Plugins!!
-# plugins = ["pg_table_access", "intercept"]
+# query_router_plugins = ["pg_table_access", "intercept"]
 
 # pool configs are structured as pool.<pool_name>
 # the pool_name is what clients use as database name when connecting.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -12,9 +12,9 @@ use tokio::time::Instant;
 use crate::config::{get_config, reload_config, VERSION};
 use crate::errors::Error;
 use crate::messages::*;
+use crate::pool::ClientServerMap;
 use crate::pool::{get_all_pools, get_pool};
 use crate::stats::{get_client_stats, get_pool_stats, get_server_stats, ClientState, ServerState};
-use crate::ClientServerMap;
 
 pub fn generate_server_info_for_admin() -> BytesMut {
     let mut server_info = BytesMut::new();

--- a/src/client.rs
+++ b/src/client.rs
@@ -766,7 +766,7 @@ where
 
         self.stats.register(self.stats.clone());
 
-        // Error returned by one of the plugins.
+        // Result returned by one of the plugins.
         let mut plugin_output = None;
 
         // Our custom protocol loop.

--- a/src/client.rs
+++ b/src/client.rs
@@ -815,7 +815,9 @@ where
 
                 'Q' => {
                     if query_router.query_parser_enabled() {
-                        query_router.infer(&message);
+                        if let Ok(ast) = QueryRouter::parse(&message) {
+                            let _ = query_router.infer(&ast);
+                        }
                     }
                 }
 
@@ -823,7 +825,9 @@ where
                     self.buffer.put(&message[..]);
 
                     if query_router.query_parser_enabled() {
-                        query_router.infer(&message);
+                        if let Ok(ast) = QueryRouter::parse(&message) {
+                            let _ = query_router.infer(&ast);
+                        }
                     }
 
                     continue;

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,7 @@ use crate::auth_passthrough::refetch_auth_hash;
 use crate::config::{get_config, get_idle_client_in_transaction_timeout, Address, PoolMode};
 use crate::constants::*;
 use crate::messages::*;
+use crate::plugins::PluginOutput;
 use crate::pool::{get_pool, ClientServerMap, ConnectionPool};
 use crate::query_router::{Command, QueryRouter};
 use crate::server::Server;
@@ -765,6 +766,9 @@ where
 
         self.stats.register(self.stats.clone());
 
+        // Error returned by one of the plugins.
+        let mut plugin_output = None;
+
         // Our custom protocol loop.
         // We expect the client to either start a transaction with regular queries
         // or issue commands for our sharding and server selection protocol.
@@ -816,6 +820,22 @@ where
                 'Q' => {
                     if query_router.query_parser_enabled() {
                         if let Ok(ast) = QueryRouter::parse(&message) {
+                            let plugin_result = query_router.execute_plugins(&ast).await;
+
+                            match plugin_result {
+                                Ok(PluginOutput::Deny(error)) => {
+                                    error_response(&mut self.write, &error).await?;
+                                    continue;
+                                }
+
+                                Ok(PluginOutput::Intercept(result)) => {
+                                    write_all(&mut self.write, result).await?;
+                                    continue;
+                                }
+
+                                _ => (),
+                            };
+
                             let _ = query_router.infer(&ast);
                         }
                     }
@@ -826,6 +846,10 @@ where
 
                     if query_router.query_parser_enabled() {
                         if let Ok(ast) = QueryRouter::parse(&message) {
+                            if let Ok(output) = query_router.execute_plugins(&ast).await {
+                                plugin_output = Some(output);
+                            }
+
                             let _ = query_router.infer(&ast);
                         }
                     }
@@ -860,6 +884,18 @@ where
                 handle_admin(&mut self.write, message, self.client_server_map.clone()).await?;
                 continue;
             }
+
+            // Check on plugin results.
+            match plugin_output {
+                Some(PluginOutput::Deny(error)) => {
+                    self.buffer.clear();
+                    error_response(&mut self.write, &error).await?;
+                    plugin_output = None;
+                    continue;
+                }
+
+                _ => (),
+            };
 
             // Get a pool instance referenced by the most up-to-date
             // pointer. This ensures we always read the latest config
@@ -1089,6 +1125,27 @@ where
                 match code {
                     // Query
                     'Q' => {
+                        if query_router.query_parser_enabled() {
+                            if let Ok(ast) = QueryRouter::parse(&message) {
+                                let plugin_result = query_router.execute_plugins(&ast).await;
+
+                                match plugin_result {
+                                    Ok(PluginOutput::Deny(error)) => {
+                                        error_response(&mut self.write, &error).await?;
+                                        continue;
+                                    }
+
+                                    Ok(PluginOutput::Intercept(result)) => {
+                                        write_all(&mut self.write, result).await?;
+                                        continue;
+                                    }
+
+                                    _ => (),
+                                };
+
+                                let _ = query_router.infer(&ast);
+                            }
+                        }
                         debug!("Sending query to server");
 
                         self.send_and_receive_loop(
@@ -1128,6 +1185,14 @@ where
                     // Parse
                     // The query with placeholders is here, e.g. `SELECT * FROM users WHERE email = $1 AND active = $2`.
                     'P' => {
+                        if query_router.query_parser_enabled() {
+                            if let Ok(ast) = QueryRouter::parse(&message) {
+                                if let Ok(output) = query_router.execute_plugins(&ast).await {
+                                    plugin_output = Some(output);
+                                }
+                            }
+                        }
+
                         self.buffer.put(&message[..]);
                     }
 
@@ -1158,6 +1223,24 @@ where
                     // Frontend (client) is asking for the query result now.
                     'S' => {
                         debug!("Sending query to server");
+
+                        match plugin_output {
+                            Some(PluginOutput::Deny(error)) => {
+                                error_response(&mut self.write, &error).await?;
+                                plugin_output = None;
+                                self.buffer.clear();
+                                continue;
+                            }
+
+                            Some(PluginOutput::Intercept(result)) => {
+                                write_all(&mut self.write, result).await?;
+                                plugin_output = None;
+                                self.buffer.clear();
+                                continue;
+                            }
+
+                            _ => (),
+                        };
 
                         self.buffer.put(&message[..]);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -298,6 +298,7 @@ pub struct General {
     pub admin_username: String,
     pub admin_password: String,
 
+    // Support for auth query
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,6 +302,8 @@ pub struct General {
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,
+
+    pub query_router_plugins: Option<Vec<String>>,
 }
 
 impl General {
@@ -402,6 +404,7 @@ impl Default for General {
             auth_query_user: None,
             auth_query_password: None,
             server_lifetime: 1000 * 3600 * 24, // 24 hours,
+            query_router_plugins: None,
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,9 +26,6 @@ pub enum Error {
     AuthPassthroughError(String),
     UnsupportedStatement,
     QueryRouterParserError(String),
-    PermissionDenied(String),
-    PermissionDeniedTable(String),
-    QueryDenied(String),
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,9 @@ pub enum Error {
     ParseBytesError(String),
     AuthError(String),
     AuthPassthroughError(String),
+    UnsupportedStatement,
+    QueryRouterParserError(String),
+    PermissionDeniedTable(String),
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 //! Errors.
 
 /// Various errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     SocketError(String),
     ClientSocketError(String, ClientIdentifier),
@@ -26,7 +26,9 @@ pub enum Error {
     AuthPassthroughError(String),
     UnsupportedStatement,
     QueryRouterParserError(String),
+    PermissionDenied(String),
     PermissionDeniedTable(String),
+    QueryDenied(String),
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod admin;
 pub mod auth_passthrough;
+pub mod client;
 pub mod config;
 pub mod constants;
 pub mod dns_cache;
@@ -6,7 +8,10 @@ pub mod errors;
 pub mod messages;
 pub mod mirrors;
 pub mod multi_logger;
+pub mod plugins;
 pub mod pool;
+pub mod prometheus;
+pub mod query_router;
 pub mod scram;
 pub mod server;
 pub mod sharding;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,11 +62,11 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use pgcat::config::{get_config, reload_config, VERSION};
+use pgcat::dns_cache;
 use pgcat::messages::configure_socket;
 use pgcat::pool::{ClientServerMap, ConnectionPool};
 use pgcat::prometheus::start_metric_server;
 use pgcat::stats::{Collector, Reporter, REPORTER};
-use pgcat::dns_cache;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     pgcat::multi_logger::MultiLogger::init().unwrap();

--- a/src/plugins/intercept.rs
+++ b/src/plugins/intercept.rs
@@ -6,6 +6,7 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sqlparser::ast::Statement;
 use std::collections::HashMap;
@@ -34,6 +35,20 @@ pub fn configure(pools: &PoolMap) {
     }
 
     CONFIG.store(Arc::new(config));
+}
+
+// TODO: use these structs for deserialization
+#[derive(Serialize, Deserialize)]
+pub struct Rule {
+    query: String,
+    schema: Vec<Column>,
+    result: Vec<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Column {
+    name: String,
+    data_type: String,
 }
 
 /// The intercept plugin.

--- a/src/plugins/intercept.rs
+++ b/src/plugins/intercept.rs
@@ -1,0 +1,263 @@
+//! The intercept plugin.
+//!
+//! It intercepts queries and returns fake results.
+
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use sqlparser::ast::Statement;
+use std::collections::HashMap;
+
+use log::debug;
+use std::sync::Arc;
+
+use crate::{
+    errors::Error,
+    messages::{command_complete, data_row_nullable, row_description, DataType},
+    plugins::{Plugin, PluginOutput},
+    pool::{PoolIdentifier, PoolMap},
+    query_router::QueryRouter,
+};
+
+pub static CONFIG: Lazy<ArcSwap<HashMap<PoolIdentifier, Value>>> =
+    Lazy::new(|| ArcSwap::from_pointee(HashMap::new()));
+
+/// Configure the intercept plugin.
+pub fn configure(pools: &PoolMap) {
+    let mut config = HashMap::new();
+    for (identifier, _) in pools.iter() {
+        // TODO: make this configurable from a text config.
+        let value = fool_datagrip(&identifier.db, &identifier.user);
+        config.insert(identifier.clone(), value);
+    }
+
+    CONFIG.store(Arc::new(config));
+}
+
+/// The intercept plugin.
+pub struct Intercept;
+
+#[async_trait]
+impl Plugin for Intercept {
+    async fn run(
+        &mut self,
+        query_router: &QueryRouter,
+        ast: &Vec<Statement>,
+    ) -> Result<PluginOutput, Error> {
+        if ast.is_empty() {
+            return Ok(PluginOutput::Allow);
+        }
+
+        let mut result = BytesMut::new();
+        let query_map = match CONFIG.load().get(&PoolIdentifier::new(
+            &query_router.pool_settings().db,
+            &query_router.pool_settings().user.username,
+        )) {
+            Some(query_map) => query_map.clone(),
+            None => return Ok(PluginOutput::Allow),
+        };
+
+        for q in ast {
+            // Normalization
+            let q = q.to_string().to_ascii_lowercase();
+
+            for target in query_map.as_array().unwrap().iter() {
+                if target["query"].as_str().unwrap() == q {
+                    debug!("Query matched: {}", q);
+
+                    let rd = target["schema"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|row| {
+                            let row = row.as_object().unwrap();
+                            (
+                                row["name"].as_str().unwrap(),
+                                match row["data_type"].as_str().unwrap() {
+                                    "text" => DataType::Text,
+                                    "anyarray" => DataType::AnyArray,
+                                    "oid" => DataType::Oid,
+                                    "bool" => DataType::Bool,
+                                    "int4" => DataType::Int4,
+                                    _ => DataType::Any,
+                                },
+                            )
+                        })
+                        .collect::<Vec<(&str, DataType)>>();
+
+                    result.put(row_description(&rd));
+
+                    target["result"].as_array().unwrap().iter().for_each(|row| {
+                        let row = row
+                            .as_array()
+                            .unwrap()
+                            .iter()
+                            .map(|s| {
+                                let s = s.as_str().unwrap().to_string();
+
+                                if s == "" {
+                                    None
+                                } else {
+                                    Some(s)
+                                }
+                            })
+                            .collect::<Vec<Option<String>>>();
+                        result.put(data_row_nullable(&row));
+                    });
+
+                    result.put(command_complete("SELECT"));
+                }
+            }
+        }
+
+        if !result.is_empty() {
+            result.put_u8(b'Z');
+            result.put_i32(5);
+            result.put_u8(b'I');
+
+            return Ok(PluginOutput::Intercept(result));
+        } else {
+            Ok(PluginOutput::Allow)
+        }
+    }
+}
+
+/// Make IntelliJ SQL plugin believe it's talking to an actual database
+/// instead of PgCat.
+fn fool_datagrip(database: &str, user: &str) -> Value {
+    json!([
+        {
+            "query": "select current_database() as a, current_schemas(false) as b",
+            "schema": [
+                {
+                    "name": "a",
+                    "data_type": "text",
+                },
+                {
+                    "name": "b",
+                    "data_type": "anyarray",
+                },
+            ],
+
+            "result": [
+                [database, "{public}"],
+            ],
+        },
+        {
+            "query": "select current_database(), current_schema(), current_user",
+            "schema": [
+                {
+                    "name": "current_database",
+                    "data_type": "text",
+                },
+                {
+                    "name": "current_schema",
+                    "data_type": "text",
+                },
+                {
+                    "name": "current_user",
+                    "data_type": "text",
+                }
+            ],
+
+            "result": [
+                ["sharded_db", "public", "sharding_user"],
+            ],
+        },
+        {
+            "query": "select cast(n.oid as bigint) as id, datname as name, d.description, datistemplate as is_template, datallowconn as allow_connections, pg_catalog.pg_get_userbyid(n.datdba) as \"owner\" from pg_catalog.pg_database as n left join pg_catalog.pg_shdescription as d on n.oid = d.objoid order by case when datname = pg_catalog.current_database() then -cast(1 as bigint) else cast(n.oid as bigint) end",
+            "schema": [
+                {
+                    "name": "id",
+                    "data_type": "oid",
+                },
+                {
+                    "name": "name",
+                    "data_type": "text",
+                },
+                {
+                    "name": "description",
+                    "data_type": "text",
+                },
+                {
+                    "name": "is_template",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "allow_connections",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "owner",
+                    "data_type": "text",
+                }
+            ],
+            "result": [
+                ["16387", database, "", "f", "t", user],
+            ]
+        },
+        {
+            "query": "select cast(r.oid as bigint) as role_id, rolname as role_name, rolsuper as is_super, rolinherit as is_inherit, rolcreaterole as can_createrole, rolcreatedb as can_createdb, rolcanlogin as can_login, rolreplication as is_replication, rolconnlimit as conn_limit, rolvaliduntil as valid_until, rolbypassrls as bypass_rls, rolconfig as config, d.description from pg_catalog.pg_roles as r left join pg_catalog.pg_shdescription as d on d.objoid = r.oid",
+            "schema": [
+                {
+                    "name": "role_id",
+                    "data_type": "oid",
+                },
+                {
+                    "name": "role_name",
+                    "data_type": "text",
+                },
+                {
+                    "name": "is_super",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "is_inherit",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "can_createrole",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "can_createdb",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "can_login",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "is_replication",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "conn_limit",
+                    "data_type": "int4",
+                },
+                {
+                    "name": "valid_until",
+                    "data_type": "text",
+                },
+                {
+                    "name": "bypass_rls",
+                    "data_type": "bool",
+                },
+                {
+                    "name": "config",
+                    "data_type": "text",
+                },
+                {
+                    "name": "description",
+                    "data_type": "text",
+                },
+            ],
+            "result": [
+                ["10", "postgres", "f", "t", "f", "f", "t", "f", "-1", "", "f", "", ""],
+                ["16419", user, "f", "t", "f", "f", "t", "f", "-1", "", "f", "", ""],
+            ]
+        }
+    ])
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -19,7 +19,7 @@ use sqlparser::ast::Statement;
 pub use intercept::Intercept;
 pub use table_access::TableAccess;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PluginOutput {
     Allow,
     Deny(String),

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,40 @@
+//! The plugin ecosystem.
+//!
+//! Currently plugins only grant access or deny access to the database for a particual query.
+//! Example use cases:
+//!   - block known bad queries
+//!   - block access to system catalogs
+//!   - block dangerous modifications like `DROP TABLE`
+//!   - etc
+//!
+
+pub mod intercept;
+pub mod table_access;
+
+use crate::{errors::Error, query_router::QueryRouter};
+use async_trait::async_trait;
+use bytes::BytesMut;
+use sqlparser::ast::Statement;
+
+pub use intercept::Intercept;
+pub use table_access::TableAccess;
+
+#[derive(Clone)]
+pub enum PluginOutput {
+    Allow,
+    Deny(String),
+    Overwrite(Vec<Statement>),
+    Intercept(BytesMut),
+}
+
+#[async_trait]
+pub trait Plugin {
+    // Custom output is allowed because we want to extend this system
+    // to rewriting queries some day. So an output of a plugin could be
+    // a rewritten AST.
+    async fn run(
+        &mut self,
+        query_router: &QueryRouter,
+        ast: &Vec<Statement>,
+    ) -> Result<PluginOutput, Error>;
+}

--- a/src/plugins/table_access.rs
+++ b/src/plugins/table_access.rs
@@ -1,0 +1,50 @@
+//! This query router plugin will check if the user can access a particular
+//! table as part of their query. If they can't, the query will not be routed.
+
+use async_trait::async_trait;
+use sqlparser::ast::{visit_relations, Statement};
+
+use crate::{
+    errors::Error,
+    plugins::{Plugin, PluginOutput},
+    query_router::QueryRouter,
+};
+
+use core::ops::ControlFlow;
+
+pub struct TableAccess {
+    pub forbidden_tables: Vec<String>,
+}
+
+#[async_trait]
+impl Plugin for TableAccess {
+    async fn run(
+        &mut self,
+        _query_router: &QueryRouter,
+        ast: &Vec<Statement>,
+    ) -> Result<PluginOutput, Error> {
+        let mut found = None;
+
+        visit_relations(ast, |relation| {
+            let relation = relation.to_string();
+            let parts = relation.split(".").collect::<Vec<&str>>();
+            let table_name = parts.last().unwrap();
+
+            if self.forbidden_tables.contains(&table_name.to_string()) {
+                found = Some(table_name.to_string());
+                ControlFlow::<()>::Break(())
+            } else {
+                ControlFlow::<()>::Continue(())
+            }
+        });
+
+        if let Some(found) = found {
+            Ok(PluginOutput::Deny(format!(
+                "permission for table \"{}\" denied",
+                found
+            )))
+        } else {
+            Ok(PluginOutput::Allow)
+        }
+    }
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -400,8 +400,6 @@ impl ConnectionPool {
                     );
                 }
 
-                debug!("Query router: {}", pool_config.query_parser_enabled);
-
                 let pool = ConnectionPool {
                     databases: shards,
                     stats: pool_stats,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -373,12 +373,19 @@ impl ConnectionPool {
                             },
                         };
 
+                        println!("\n\n\n\n");
+                        println!("Idle timeout({}): {}", pool_name, idle_timeout);
+
                         let pool = Pool::builder()
                             .max_size(user.pool_size)
                             .min_idle(user.min_pool_size)
                             .connection_timeout(std::time::Duration::from_millis(connect_timeout))
                             .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                             .max_lifetime(Some(std::time::Duration::from_millis(server_lifetime)))
+                            .reaper_rate(std::time::Duration::from_millis(std::cmp::min(
+                                idle_timeout,
+                                server_lifetime,
+                            )))
                             .test_on_check_out(false)
                             .build(manager)
                             .await?;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -395,6 +395,8 @@ impl ConnectionPool {
                     );
                 }
 
+                debug!("Query router: {}", pool_config.query_parser_enabled);
+
                 let pool = ConnectionPool {
                     databases: shards,
                     stats: pool_stats,

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1155,6 +1155,8 @@ mod test {
             auth_query: None,
             auth_query_password: None,
             auth_query_user: None,
+            db: "test".to_string(),
+            plugins: None,
         };
         let mut qr = QueryRouter::new();
         assert_eq!(qr.active_role, None);
@@ -1228,6 +1230,8 @@ mod test {
             auth_query: None,
             auth_query_password: None,
             auth_query_user: None,
+            db: "test".to_string(),
+            plugins: None,
         };
         let mut qr = QueryRouter::new();
         qr.update_pool_settings(pool_settings.clone());

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -341,7 +341,7 @@ impl QueryRouter {
             // Query
             'Q' => {
                 let query = message_cursor.read_string().unwrap();
-                error!("Query: '{}'", query);
+                debug!("Query: '{}'", query);
                 query
             }
 
@@ -353,7 +353,7 @@ impl QueryRouter {
                 // Reads query string
                 let query = message_cursor.read_string().unwrap();
 
-                error!("Prepared statement: '{}'", query);
+                debug!("Prepared statement: '{}'", query);
                 query
             }
 

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -27,6 +27,7 @@ module Helpers
       primary2 = PgInstance.new(8432, user["username"], user["password"], "shard2")
 
       pgcat_cfg = pgcat.current_config
+      pgcat_cfg["general"]["query_router_plugins"] = ["intercept"]
       pgcat_cfg["pools"] = {
         "#{pool_name}" => {
           "default_role" => "any",

--- a/tests/ruby/plugins_spec.rb
+++ b/tests/ruby/plugins_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+
+
+describe "Plugins" do
+  let(:processes) { Helpers::Pgcat.three_shard_setup("sharded_db", 5) }
+
+  context "intercept" do
+    it "will intercept an intellij query" do
+      conn = PG.connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+      res = conn.exec("select current_database() as a, current_schemas(false) as b")
+      expect(res.values).to eq([["sharded_db", "{public}"]])
+    end
+  end
+end


### PR DESCRIPTION
### Feature

Introducing plugins.

The idea is to perform an action based on a query.

Currently, the actions I'm thinking of could be:
- let the query go through unharmed
- block the query and return an error immediately
- intercept the query and return a fake result
- rewrite the query (like pgbouncer-rr-patch)

The last one isn't supported yet, but maybe someone with a use case could contribute a PR.

### Why

Well, a couple reasons. First, I want to block users from querying certain system tables. Postgres doesn't let me do that, and that's fine. The query planner may need them, but the user doesn't need to explicitly query them, so that solves that problem.

Another reason, I just discovered the joy of using IDEs like DataGrip (IntelliJ), and they get pretty upset when they are talking to a pooler. The included `fool_datagrip` function returns fake information about the "database" It's connected to, so DataGrip doesn't complain.

### Bug fixes

Increase default pool reaper rate to match `min(idle_timeout, server_lifetime)`.