### PR TITLE
Fix docker-compose dev stack for Apple silicon

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -25,7 +25,7 @@ x-common-env-pg:
 
 services:
   main:
-    image: kubernetes/pause
+    image: gcr.io/google_containers/pause:3.2
     ports:
       - 6432
 
@@ -64,7 +64,7 @@ services:
       <<: *common-env-pg
       POSTGRES_INITDB_ARGS: --auth-local=md5 --auth-host=md5 --auth=md5
       PGPORT: 10432
-    command: ["postgres", "-p", "5432", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "pg_stat_statements.max=100000"]
+    command: ["postgres", "-p", "10432", "-c", "shared_preload_libraries=pg_stat_statements", "-c", "pg_stat_statements.track=all", "-c", "pg_stat_statements.max=100000"]
 
   toxiproxy:
     build: .


### PR DESCRIPTION
The docker-compose dev setup is broken under Apple silicon, starting the stack fails with the following error. Switching to a different docker image fixes the issue.
<img width="1210" alt="Screen Shot 2023-05-10 at 10 04 53 AM" src="https://github.com/postgresml/pgcat/assets/202050/67379060-42ad-47e0-8b56-9701f4819b41">
