### PR TITLE
Prewarmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pgcat"
-version = "1.0.2-alpha1"
+version = "1.0.2-alpha2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "1.0.2-alpha1"
+version = "1.0.2-alpha2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pgcat.minimal.toml
+++ b/pgcat.minimal.toml
@@ -1,0 +1,23 @@
+# This is an example of the most basic config
+# that will mimic what PgBouncer does in transaction mode with one server.
+
+[general]
+
+host = "0.0.0.0"
+port = 6433
+connect_timeout = 1000
+admin_username = "pgcat"
+admin_password = "pgcat"
+
+[pools.pgml.users.0]
+username = "postgres"
+password = "postgres"
+pool_size = 10
+min_pool_size = 1
+pool_mode = "transaction"
+
+[pools.pgml.shards.0]
+servers = [
+  ["127.0.0.1", 28815, "primary"]
+]
+database = "postgres"

--- a/pgcat.minimal.toml
+++ b/pgcat.minimal.toml
@@ -5,7 +5,6 @@
 
 host = "0.0.0.0"
 port = 6433
-connect_timeout = 1000
 admin_username = "pgcat"
 admin_password = "pgcat"
 

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -77,6 +77,58 @@ admin_username = "admin_user"
 # Password to access the virtual administrative database
 admin_password = "admin_pass"
 
+# Default plugins that are configured on all pools.
+[plugins]
+
+# Prewarmer plugin that runs queries on server startup, before giving the connection
+# to the client.
+[plugins.prewarmer]
+enabled = false
+queries = [
+  "SELECT pg_prewarm('pgbench_accounts')",
+]
+
+# Log all queries to stdout.
+[plugins.query_logger]
+enabled = false
+
+# Block access to tables that Postgres does not allow us to control.
+[plugins.table_access]
+enabled = false
+tables = [
+  "pg_user",
+  "pg_roles",
+  "pg_database",
+]
+
+# Intercept user queries and give a fake reply.
+[plugins.intercept]
+enabled = true
+
+[plugins.intercept.queries.0]
+
+query = "select current_database() as a, current_schemas(false) as b"
+schema = [
+  ["a", "text"],
+  ["b", "text"],
+]
+result = [
+  ["${DATABASE}", "{public}"],
+]
+
+[plugins.intercept.queries.1]
+
+query = "select current_database(), current_schema(), current_user"
+schema = [
+  ["current_database", "text"],
+  ["current_schema", "text"],
+  ["current_user", "text"],
+]
+result = [
+  ["${DATABASE}", "public", "${USER}"],
+]
+
+
 # pool configs are structured as pool.<pool_name>
 # the pool_name is what clients use as database name when connecting.
 # For a pool named `sharded_db`, clients access that pool using connection string like
@@ -154,10 +206,12 @@ connect_timeout = 3000
 # Specifies how often (in seconds) cached ip addresses for servers are rechecked (see `dns_cache_enabled`).
 # dns_max_ttl = 30
 
+# Plugins can be configured on a pool-per-pool basis. This overrides the global plugins setting,
+# so all plugins have to be configured here again.
 [pool.sharded_db.plugins]
 
 [pools.sharded_db.plugins.prewarmer]
-enabled = false
+enabled = true
 queries = [
   "SELECT pg_prewarm('pgbench_accounts')",
 ]

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -156,8 +156,14 @@ connect_timeout = 3000
 
 [plugins]
 
-[plugins.query_logger]
+[plugins.prewarmer]
 enabled = false
+queries = [
+  "SELECT pg_prewarm('pgbench_accounts')",
+]
+
+[plugins.query_logger]
+enabled = true
 
 [plugins.table_access]
 enabled = false

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -157,16 +157,16 @@ connect_timeout = 3000
 [pool.sharded_db.plugins]
 
 [pools.sharded_db.plugins.prewarmer]
-enabled = true
+enabled = false
 queries = [
   "SELECT pg_prewarm('pgbench_accounts')",
 ]
 
 [pools.sharded_db.plugins.query_logger]
-enabled = true
+enabled = false
 
 [pools.sharded_db.plugins.table_access]
-enabled = true
+enabled = false
 tables = [
   "pg_user",
   "pg_roles",

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -154,29 +154,29 @@ connect_timeout = 3000
 # Specifies how often (in seconds) cached ip addresses for servers are rechecked (see `dns_cache_enabled`).
 # dns_max_ttl = 30
 
-[plugins]
+[pool.sharded_db.plugins]
 
-[plugins.prewarmer]
-enabled = false
+[pools.sharded_db.plugins.prewarmer]
+enabled = true
 queries = [
   "SELECT pg_prewarm('pgbench_accounts')",
 ]
 
-[plugins.query_logger]
+[pools.sharded_db.plugins.query_logger]
 enabled = true
 
-[plugins.table_access]
-enabled = false
+[pools.sharded_db.plugins.table_access]
+enabled = true
 tables = [
   "pg_user",
   "pg_roles",
   "pg_database",
 ]
 
-[plugins.intercept]
+[pools.sharded_db.plugins.intercept]
 enabled = true
 
-[plugins.intercept.queries.0]
+[pools.sharded_db.plugins.intercept.queries.0]
 
 query = "select current_database() as a, current_schemas(false) as b"
 schema = [
@@ -187,7 +187,7 @@ result = [
   ["${DATABASE}", "{public}"],
 ]
 
-[plugins.intercept.queries.1]
+[pools.sharded_db.plugins.intercept.queries.1]
 
 query = "select current_database(), current_schema(), current_user"
 schema = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -692,6 +692,7 @@ pub struct Plugins {
     pub intercept: Option<Intercept>,
     pub table_access: Option<TableAccess>,
     pub query_logger: Option<QueryLogger>,
+    pub prewarmer: Option<Prewarmer>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -709,6 +710,12 @@ pub struct TableAccess {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct QueryLogger {
     pub enabled: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct Prewarmer {
+    pub enabled: bool,
+    pub queries: Vec<String>,
 }
 
 impl Intercept {

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -43,6 +43,7 @@ impl MirroredClient {
             ClientServerMap::default(),
             Arc::new(PoolStats::new(identifier, cfg.clone())),
             Arc::new(RwLock::new(None)),
+            None,
         );
 
         Pool::builder()

--- a/src/plugins/intercept.rs
+++ b/src/plugins/intercept.rs
@@ -2,51 +2,20 @@
 //!
 //! It intercepts queries and returns fake results.
 
-use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
 use sqlparser::ast::Statement;
-use std::collections::HashMap;
 
-use log::{debug, info};
-use std::sync::Arc;
+use log::debug;
 
 use crate::{
     config::Intercept as InterceptConfig,
     errors::Error,
     messages::{command_complete, data_row_nullable, row_description, DataType},
     plugins::{Plugin, PluginOutput},
-    pool::{PoolIdentifier, PoolMap},
     query_router::QueryRouter,
 };
-
-pub static CONFIG: Lazy<ArcSwap<HashMap<PoolIdentifier, InterceptConfig>>> =
-    Lazy::new(|| ArcSwap::from_pointee(HashMap::new()));
-
-/// Check if the interceptor plugin has been enabled.
-pub fn enabled() -> bool {
-    !CONFIG.load().is_empty()
-}
-
-pub fn setup(intercept_config: &InterceptConfig, pools: &PoolMap) {
-    let mut config = HashMap::new();
-    for (identifier, _) in pools.iter() {
-        let mut intercept_config = intercept_config.clone();
-        intercept_config.substitute(&identifier.db, &identifier.user);
-        config.insert(identifier.clone(), intercept_config);
-    }
-
-    CONFIG.store(Arc::new(config));
-
-    info!("Intercepting {} queries", intercept_config.queries.len());
-}
-
-pub fn disable() {
-    CONFIG.store(Arc::new(HashMap::new()));
-}
 
 // TODO: use these structs for deserialization
 #[derive(Serialize, Deserialize)]
@@ -63,33 +32,35 @@ pub struct Column {
 }
 
 /// The intercept plugin.
-pub struct Intercept;
+pub struct Intercept<'a> {
+    pub enabled: bool,
+    pub config: &'a InterceptConfig,
+}
 
 #[async_trait]
-impl Plugin for Intercept {
+impl<'a> Plugin for Intercept<'a> {
     async fn run(
         &mut self,
         query_router: &QueryRouter,
         ast: &Vec<Statement>,
     ) -> Result<PluginOutput, Error> {
-        if ast.is_empty() {
+        if !self.enabled || ast.is_empty() {
             return Ok(PluginOutput::Allow);
         }
 
-        let mut result = BytesMut::new();
-        let query_map = match CONFIG.load().get(&PoolIdentifier::new(
+        let mut config = self.config.clone();
+        config.substitute(
             &query_router.pool_settings().db,
             &query_router.pool_settings().user.username,
-        )) {
-            Some(query_map) => query_map.clone(),
-            None => return Ok(PluginOutput::Allow),
-        };
+        );
+
+        let mut result = BytesMut::new();
 
         for q in ast {
             // Normalization
             let q = q.to_string().to_ascii_lowercase();
 
-            for (_, target) in query_map.queries.iter() {
+            for (_, target) in config.queries.iter() {
                 if target.query.as_str() == q {
                     debug!("Intercepting query: {}", q);
 
@@ -146,143 +117,4 @@ impl Plugin for Intercept {
             Ok(PluginOutput::Allow)
         }
     }
-}
-
-/// Make IntelliJ SQL plugin believe it's talking to an actual database
-/// instead of PgCat.
-#[allow(dead_code)]
-fn fool_datagrip(database: &str, user: &str) -> Value {
-    json!([
-        {
-            "query": "select current_database() as a, current_schemas(false) as b",
-            "schema": [
-                {
-                    "name": "a",
-                    "data_type": "text",
-                },
-                {
-                    "name": "b",
-                    "data_type": "anyarray",
-                },
-            ],
-
-            "result": [
-                [database, "{public}"],
-            ],
-        },
-        {
-            "query": "select current_database(), current_schema(), current_user",
-            "schema": [
-                {
-                    "name": "current_database",
-                    "data_type": "text",
-                },
-                {
-                    "name": "current_schema",
-                    "data_type": "text",
-                },
-                {
-                    "name": "current_user",
-                    "data_type": "text",
-                }
-            ],
-
-            "result": [
-                ["sharded_db", "public", "sharding_user"],
-            ],
-        },
-        {
-            "query": "select cast(n.oid as bigint) as id, datname as name, d.description, datistemplate as is_template, datallowconn as allow_connections, pg_catalog.pg_get_userbyid(n.datdba) as \"owner\" from pg_catalog.pg_database as n left join pg_catalog.pg_shdescription as d on n.oid = d.objoid order by case when datname = pg_catalog.current_database() then -cast(1 as bigint) else cast(n.oid as bigint) end",
-            "schema": [
-                {
-                    "name": "id",
-                    "data_type": "oid",
-                },
-                {
-                    "name": "name",
-                    "data_type": "text",
-                },
-                {
-                    "name": "description",
-                    "data_type": "text",
-                },
-                {
-                    "name": "is_template",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "allow_connections",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "owner",
-                    "data_type": "text",
-                }
-            ],
-            "result": [
-                ["16387", database, "", "f", "t", user],
-            ]
-        },
-        {
-            "query": "select cast(r.oid as bigint) as role_id, rolname as role_name, rolsuper as is_super, rolinherit as is_inherit, rolcreaterole as can_createrole, rolcreatedb as can_createdb, rolcanlogin as can_login, rolreplication as is_replication, rolconnlimit as conn_limit, rolvaliduntil as valid_until, rolbypassrls as bypass_rls, rolconfig as config, d.description from pg_catalog.pg_roles as r left join pg_catalog.pg_shdescription as d on d.objoid = r.oid",
-            "schema": [
-                {
-                    "name": "role_id",
-                    "data_type": "oid",
-                },
-                {
-                    "name": "role_name",
-                    "data_type": "text",
-                },
-                {
-                    "name": "is_super",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "is_inherit",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "can_createrole",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "can_createdb",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "can_login",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "is_replication",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "conn_limit",
-                    "data_type": "int4",
-                },
-                {
-                    "name": "valid_until",
-                    "data_type": "text",
-                },
-                {
-                    "name": "bypass_rls",
-                    "data_type": "bool",
-                },
-                {
-                    "name": "config",
-                    "data_type": "text",
-                },
-                {
-                    "name": "description",
-                    "data_type": "text",
-                },
-            ],
-            "result": [
-                ["10", "postgres", "f", "t", "f", "f", "t", "f", "-1", "", "f", "", ""],
-                ["16419", user, "f", "t", "f", "f", "t", "f", "-1", "", "f", "", ""],
-            ]
-        }
-    ])
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -9,6 +9,7 @@
 //!
 
 pub mod intercept;
+pub mod prewarmer;
 pub mod query_logger;
 pub mod table_access;
 

--- a/src/plugins/prewarmer.rs
+++ b/src/plugins/prewarmer.rs
@@ -16,7 +16,7 @@ impl<'a> Prewarmer<'a> {
 
         for query in self.queries {
             info!(
-                "Prewarning {:?} with query: `{}`",
+                "{} Prewarning with query: `{}`",
                 self.server.address(),
                 query
             );

--- a/src/plugins/prewarmer.rs
+++ b/src/plugins/prewarmer.rs
@@ -1,0 +1,48 @@
+//! Prewarm new connections before giving them to the client.
+use crate::{errors::Error, server::Server};
+use arc_swap::ArcSwap;
+// use async_trait::async_trait;
+use log::info;
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+static QUERIES: Lazy<ArcSwap<Vec<String>>> = Lazy::new(|| ArcSwap::from_pointee(Vec::new()));
+
+pub struct Prewarmer;
+
+pub fn setup(queries: &Vec<String>) {
+    QUERIES.store(Arc::new(queries.clone()));
+
+    info!("Query prewarmer enabled.");
+
+    for query in queries {
+        info!("Prewarming query: {}", query);
+    }
+}
+
+pub fn disable() {
+    QUERIES.store(Arc::new(vec![]));
+}
+
+pub fn enabled() -> bool {
+    !QUERIES.load().is_empty()
+}
+
+// TODO: come up with a decent interface for server plugins.
+
+pub async fn run(server: &mut Server) -> Result<(), Error> {
+    let mut queries = Vec::new();
+
+    // Don't want  to hold arcswap while we run these potentially slow queries.
+    {
+        for query in QUERIES.load().iter() {
+            queries.push(query.clone());
+        }
+    }
+
+    for query in queries {
+        server.query(&query).await?;
+    }
+
+    Ok(())
+}

--- a/src/plugins/query_logger.rs
+++ b/src/plugins/query_logger.rs
@@ -5,44 +5,33 @@ use crate::{
     plugins::{Plugin, PluginOutput},
     query_router::QueryRouter,
 };
-use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use log::info;
-use once_cell::sync::Lazy;
 use sqlparser::ast::Statement;
-use std::sync::Arc;
 
-static ENABLED: Lazy<ArcSwap<bool>> = Lazy::new(|| ArcSwap::from_pointee(false));
-
-pub struct QueryLogger;
-
-pub fn setup() {
-    ENABLED.store(Arc::new(true));
-
-    info!("Logging queries to stdout");
-}
-
-pub fn disable() {
-    ENABLED.store(Arc::new(false));
-}
-
-pub fn enabled() -> bool {
-    **ENABLED.load()
+pub struct QueryLogger<'a> {
+    pub enabled: bool,
+    pub user: &'a str,
+    pub db: &'a str,
 }
 
 #[async_trait]
-impl Plugin for QueryLogger {
+impl<'a> Plugin for QueryLogger<'a> {
     async fn run(
         &mut self,
         _query_router: &QueryRouter,
         ast: &Vec<Statement>,
     ) -> Result<PluginOutput, Error> {
+        if !self.enabled {
+            return Ok(PluginOutput::Allow);
+        }
+
         let query = ast
             .iter()
             .map(|q| q.to_string())
             .collect::<Vec<String>>()
             .join("; ");
-        info!("{}", query);
+        info!("[pool: {}][user: {}] {}", self.user, self.db, query);
 
         Ok(PluginOutput::Allow)
     }

--- a/src/plugins/table_access.rs
+++ b/src/plugins/table_access.rs
@@ -5,34 +5,14 @@ use async_trait::async_trait;
 use sqlparser::ast::{visit_relations, Statement};
 
 use crate::{
-    config::TableAccess as TableAccessConfig,
     errors::Error,
     plugins::{Plugin, PluginOutput},
     query_router::QueryRouter,
 };
 
-use log::{debug, info};
+use log::debug;
 
-use arc_swap::ArcSwap;
 use core::ops::ControlFlow;
-use once_cell::sync::Lazy;
-use std::sync::Arc;
-
-static CONFIG: Lazy<ArcSwap<Vec<String>>> = Lazy::new(|| ArcSwap::from_pointee(vec![]));
-
-pub fn setup(config: &TableAccessConfig) {
-    CONFIG.store(Arc::new(config.tables.clone()));
-
-    info!("Blocking access to {} tables", config.tables.len());
-}
-
-pub fn enabled() -> bool {
-    !CONFIG.load().is_empty()
-}
-
-pub fn disable() {
-    CONFIG.store(Arc::new(vec![]));
-}
 
 pub struct TableAccess<'a> {
     pub enabled: bool,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -17,7 +17,9 @@ use std::sync::{
 use std::time::Instant;
 use tokio::sync::Notify;
 
-use crate::config::{get_config, Address, General, LoadBalancingMode, PoolMode, Role, User};
+use crate::config::{
+    get_config, Address, General, LoadBalancingMode, Plugins, PoolMode, Role, User,
+};
 use crate::errors::Error;
 
 use crate::auth_passthrough::AuthPassthrough;
@@ -133,6 +135,9 @@ pub struct PoolSettings {
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,
+
+    /// Plugins
+    pub plugins: Option<Plugins>,
 }
 
 impl Default for PoolSettings {
@@ -157,6 +162,7 @@ impl Default for PoolSettings {
             auth_query: None,
             auth_query_user: None,
             auth_query_password: None,
+            plugins: None,
         }
     }
 }
@@ -196,6 +202,7 @@ pub struct ConnectionPool {
     paused: Arc<AtomicBool>,
     paused_waiter: Arc<Notify>,
 
+    /// Statistics.
     pub stats: Arc<PoolStats>,
 
     /// AuthInfo
@@ -209,41 +216,6 @@ impl ConnectionPool {
 
         let mut new_pools = HashMap::new();
         let mut address_id: usize = 0;
-
-        // Enable plugins, if configured
-        if let Some(ref plugins) = config.plugins {
-            if let Some(ref intercept) = plugins.intercept {
-                if intercept.enabled {
-                    crate::plugins::intercept::setup(intercept, &new_pools);
-                } else {
-                    crate::plugins::intercept::disable();
-                }
-            }
-
-            if let Some(ref table_access) = plugins.table_access {
-                if table_access.enabled {
-                    crate::plugins::table_access::setup(table_access);
-                } else {
-                    crate::plugins::table_access::disable();
-                }
-            }
-
-            if let Some(ref query_logger) = plugins.query_logger {
-                if query_logger.enabled {
-                    crate::plugins::query_logger::setup();
-                } else {
-                    crate::plugins::query_logger::disable();
-                }
-            }
-
-            if let Some(ref prewarmer) = plugins.prewarmer {
-                if prewarmer.enabled {
-                    crate::plugins::prewarmer::setup(&prewarmer.queries);
-                } else {
-                    crate::plugins::prewarmer::disable();
-                }
-            }
-        }
 
         for (pool_name, pool_config) in &config.pools {
             let new_pool_hash_value = pool_config.hash_value();
@@ -388,6 +360,7 @@ impl ConnectionPool {
                             client_server_map.clone(),
                             pool_stats.clone(),
                             pool_auth_hash.clone(),
+                            pool_config.plugins.clone(),
                         );
 
                         let connect_timeout = match pool_config.connect_timeout {
@@ -413,7 +386,10 @@ impl ConnectionPool {
                             .min()
                             .unwrap();
 
-                        debug!("Pool reaper rate: {}ms", reaper_rate);
+                        debug!(
+                            "[pool: {}][user: {}] Pool reaper rate: {}ms",
+                            pool_name, user.username, reaper_rate
+                        );
 
                         let pool = Pool::builder()
                             .max_size(user.pool_size)
@@ -486,6 +462,7 @@ impl ConnectionPool {
                         auth_query: pool_config.auth_query.clone(),
                         auth_query_user: pool_config.auth_query_user.clone(),
                         auth_query_password: pool_config.auth_query_password.clone(),
+                        plugins: pool_config.plugins.clone(),
                     },
                     validated: Arc::new(AtomicBool::new(false)),
                     paused: Arc::new(AtomicBool::new(false)),
@@ -933,6 +910,7 @@ pub struct ServerPool {
     client_server_map: ClientServerMap,
     stats: Arc<PoolStats>,
     auth_hash: Arc<RwLock<Option<String>>>,
+    plugins: Option<Plugins>,
 }
 
 impl ServerPool {
@@ -943,6 +921,7 @@ impl ServerPool {
         client_server_map: ClientServerMap,
         stats: Arc<PoolStats>,
         auth_hash: Arc<RwLock<Option<String>>>,
+        plugins: Option<Plugins>,
     ) -> ServerPool {
         ServerPool {
             address,
@@ -951,6 +930,7 @@ impl ServerPool {
             client_server_map,
             stats,
             auth_hash,
+            plugins,
         }
     }
 }
@@ -984,8 +964,16 @@ impl ManageConnection for ServerPool {
         .await
         {
             Ok(mut conn) => {
-                if prewarmer::enabled() {
-                    prewarmer::run(&mut conn).await?;
+                if let Some(ref plugins) = self.plugins {
+                    if let Some(ref prewarmer) = plugins.prewarmer {
+                        let mut prewarmer = prewarmer::Prewarmer {
+                            enabled: prewarmer.enabled,
+                            server: &mut conn,
+                            queries: &prewarmer.queries,
+                        };
+
+                        prewarmer.run().await?;
+                    }
                 }
 
                 stats.idle();

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -360,7 +360,10 @@ impl ConnectionPool {
                             client_server_map.clone(),
                             pool_stats.clone(),
                             pool_auth_hash.clone(),
-                            pool_config.plugins.clone(),
+                            match pool_config.plugins {
+                                Some(ref plugins) => Some(plugins.clone()),
+                                None => config.plugins.clone(),
+                            },
                         );
 
                         let connect_timeout = match pool_config.connect_timeout {
@@ -462,7 +465,10 @@ impl ConnectionPool {
                         auth_query: pool_config.auth_query.clone(),
                         auth_query_user: pool_config.auth_query_user.clone(),
                         auth_query_password: pool_config.auth_query_password.clone(),
-                        plugins: pool_config.plugins.clone(),
+                        plugins: match pool_config.plugins {
+                            Some(ref plugins) => Some(plugins.clone()),
+                            None => config.plugins.clone(),
+                        },
                     },
                     validated: Arc::new(AtomicBool::new(false)),
                     paused: Arc::new(AtomicBool::new(false)),

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1176,6 +1176,7 @@ mod test {
             auth_query_password: None,
             auth_query_user: None,
             db: "test".to_string(),
+            plugins: None,
         };
         let mut qr = QueryRouter::new();
         assert_eq!(qr.active_role, None);
@@ -1250,7 +1251,9 @@ mod test {
             auth_query_password: None,
             auth_query_user: None,
             db: "test".to_string(),
+            plugins: None,
         };
+
         let mut qr = QueryRouter::new();
         qr.update_pool_settings(pool_settings.clone());
 
@@ -1394,17 +1397,25 @@ mod test {
 
     #[tokio::test]
     async fn test_table_access_plugin() {
-        use crate::config::TableAccess;
-        let ta = TableAccess {
+        use crate::config::{Plugins, TableAccess};
+        let table_access = TableAccess {
             enabled: true,
             tables: vec![String::from("pg_database")],
         };
-
-        crate::plugins::table_access::setup(&ta);
+        let plugins = Plugins {
+            table_access: Some(table_access),
+            intercept: None,
+            query_logger: None,
+            prewarmer: None,
+        };
 
         QueryRouter::setup();
+        let mut pool_settings = PoolSettings::default();
+        pool_settings.query_parser_enabled = true;
+        pool_settings.plugins = Some(plugins);
 
-        let qr = QueryRouter::new();
+        let mut qr = QueryRouter::new();
+        qr.update_pool_settings(pool_settings);
 
         let query = simple_query("SELECT * FROM pg_database");
         let ast = QueryRouter::parse(&query).unwrap();
@@ -1417,5 +1428,18 @@ mod test {
                 "permission for table \"pg_database\" denied".to_string()
             ))
         );
+    }
+
+    #[tokio::test]
+    async fn test_plugins_disabled_by_defaault() {
+        QueryRouter::setup();
+        let qr = QueryRouter::new();
+
+        let query = simple_query("SELECT * FROM pg_database");
+        let ast = QueryRouter::parse(&query).unwrap();
+
+        let res = qr.execute_plugins(&ast).await;
+
+        assert_eq!(res, Ok(PluginOutput::Allow));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -928,6 +928,8 @@ impl Server {
     /// It will use the simple query protocol.
     /// Result will not be returned, so this is useful for things like `SET` or `ROLLBACK`.
     pub async fn query(&mut self, query: &str) -> Result<(), Error> {
+        debug!("Running `{}` on server {:?}", query, self.address);
+
         let query = simple_query(query);
 
         self.send(&query).await?;

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -41,7 +41,24 @@ module Helpers
             "1" => { "database" => "shard1", "servers" => [["localhost", primary1.port.to_s, "primary"]] },
             "2" => { "database" => "shard2", "servers" => [["localhost", primary2.port.to_s, "primary"]] },
           },
-          "users" => { "0" => user }
+          "users" => { "0" => user },
+          "plugins" => {
+            "intercept" => {
+              "enabled" => true,
+              "queries" => {
+                "0" => {
+                  "query" => "select current_database() as a, current_schemas(false) as b",
+                  "schema" => [
+                      ["a", "text"],
+                      ["b", "text"],
+                  ],
+                  "result" => [
+                    ["${DATABASE}", "{public}"],
+                  ]
+                }
+              }
+            }
+          }
         }
       }
       pgcat.update_config(pgcat_cfg)


### PR DESCRIPTION
### Feature

#### Prewarmer plugin
A plugin for running queries on server startup. This can be used to create necessary objects, prewarm tables, or set settings on the connection.

#### Config
Plugins can now be configured per pool and not just globally.


### Bug fixes
Added missing defaults for some obscure settings in pgcat.toml, to minimize the required configuration when setting up for the first time.

### Misc

Added an example of a minimal config in `pgcat.minimal.toml`.
