### PR TITLE
Fixes average stats bug

### DIFF
--- a/src/stats/server.rs
+++ b/src/stats/server.rs
@@ -139,6 +139,17 @@ impl ServerStats {
         self.address.stats.clone()
     }
 
+    pub fn check_address_stat_average_is_updated_status(&self) -> bool {
+        self.address.stats.averages_updated.load(Ordering::Relaxed)
+    }
+
+    pub fn set_address_stat_average_is_updated_status(&self, is_checked: bool) {
+        self.address
+            .stats
+            .averages_updated
+            .store(is_checked, Ordering::Relaxed);
+    }
+
     // Helper methods for show_servers
     pub fn pool_name(&self) -> String {
         self.pool_stats.database()

--- a/tests/ruby/admin_spec.rb
+++ b/tests/ruby/admin_spec.rb
@@ -26,7 +26,7 @@ describe "Admin" do
         results = admin_conn.async_exec("SHOW STATS")[0]
         admin_conn.close
         expect(results["total_query_time"].to_i).to be_within(200).of(750)
-        expect(results["avg_query_time"].to_i).to_not eq(0)
+        expect(results["avg_query_time"].to_i).to be_within(20).of(50)
 
         expect(results["total_wait_time"].to_i).to_not eq(0)
         expect(results["avg_wait_time"].to_i).to_not eq(0)


### PR DESCRIPTION
When there are multiple concurrent active servers, the stats reporting reports a 0 value average. This is because of the old value being updated and then the average being overridden when a new server pointing to the same address stats gets updated.
```
SERVER STATS: "postgres_shard_0_replica_0", 452826896
total_value: 1648, old_value: 0
average: 329
SERVER STATS: "postgres_shard_0_replica_1", -1989878371
total_value: 1585, old_value: 0
average: 317
SERVER STATS: "postgres_shard_0_replica_0", 1447777444
total_value: 1648, old_value: 1648
average: 0
SERVER STATS: "postgres_shard_0_replica_0", -1279761882
total_value: 1648, old_value: 1648
average: 0
SERVER STATS: "postgres_shard_0_replica_1", 1763453831
total_value: 1585, old_value: 1585
average: 0
SERVER STATS: "postgres_shard_0_replica_1", 2126090134
total_value: 1585, old_value: 1585
average: 0
SERVER STATS: "postgres_shard_0_replica_0", -969830376
total_value: 1648, old_value: 1648
average: 0
```

This PR fixes this by running a check to make sure that we only ever do this once for any given AddressStats Arc object.