### PR TITLE
Allow to deploy pools without checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pgcat"
-version = "1.0.2-alpha2"
+version = "1.0.2-alpha3"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "1.0.2-alpha2"
+version = "1.0.2-alpha3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -401,9 +401,13 @@ impl ConnectionPool {
                             .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                             .max_lifetime(Some(std::time::Duration::from_millis(server_lifetime)))
                             .reaper_rate(std::time::Duration::from_millis(reaper_rate))
-                            .test_on_check_out(false)
-                            .build(manager)
-                            .await?;
+                            .test_on_check_out(false);
+
+                        let pool = if config.general.validate_config {
+                            pool.build(manager).await?
+                        } else {
+                            pool.build_unchecked(manager)
+                        };
 
                         pools.push(pool);
                         servers.push(address);


### PR DESCRIPTION
### Feature/Bug

Don't synchronously create the pool and initilize connections unless we set `validate_config` to true. The default behavior is to initialize and validate, as before.