### PR TITLE
Optionally clean up server connections

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -313,9 +313,6 @@ pub struct General {
     #[serde(default = "General::default_validate_config")]
     pub validate_config: bool,
 
-    #[serde(default = "General::default_cleanup_server_connections")]
-    pub cleanup_server_connections: bool,
-
     // Support for auth query
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
@@ -393,10 +390,6 @@ impl General {
     pub fn default_prometheus_exporter_port() -> i16 {
         9930
     }
-
-    pub fn default_cleanup_server_connections() -> bool {
-        true
-    }
 }
 
 impl Default for General {
@@ -433,7 +426,6 @@ impl Default for General {
             auth_query_password: None,
             server_lifetime: 1000 * 3600 * 24, // 24 hours,
             validate_config: true,
-            cleanup_server_connections: true,
         }
     }
 }
@@ -520,6 +512,9 @@ pub struct Pool {
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,
 
+    #[serde(default = "Pool::default_cleanup_server_connections")]
+    pub cleanup_server_connections: bool,
+
     pub plugins: Option<Plugins>,
     pub shards: BTreeMap<String, Shard>,
     pub users: BTreeMap<String, User>,
@@ -559,6 +554,10 @@ impl Pool {
 
     pub fn default_sharding_function() -> ShardingFunction {
         ShardingFunction::PgBigintHash
+    }
+
+    pub fn default_cleanup_server_connections() -> bool {
+        true
     }
 
     pub fn validate(&mut self) -> Result<(), Error> {
@@ -650,6 +649,7 @@ impl Default for Pool {
             auth_query_password: None,
             server_lifetime: None,
             plugins: None,
+            cleanup_server_connections: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,6 +313,9 @@ pub struct General {
     #[serde(default = "General::default_validate_config")]
     pub validate_config: bool,
 
+    #[serde(default = "General::default_cleanup_server_connections")]
+    pub cleanup_server_connections: bool,
+
     // Support for auth query
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
@@ -390,6 +393,10 @@ impl General {
     pub fn default_prometheus_exporter_port() -> i16 {
         9930
     }
+
+    pub fn default_cleanup_server_connections() -> bool {
+        true
+    }
 }
 
 impl Default for General {
@@ -426,6 +433,7 @@ impl Default for General {
             auth_query_password: None,
             server_lifetime: 1000 * 3600 * 24, // 24 hours,
             validate_config: true,
+            cleanup_server_connections: true,
         }
     }
 }
@@ -487,10 +495,15 @@ pub struct Pool {
     #[serde(default)] // False
     pub primary_reads_enabled: bool,
 
+    /// Maximum time to allow for establishing a new server connection.
     pub connect_timeout: Option<u64>,
 
+    /// Close idle connections that have been opened for longer than this.
     pub idle_timeout: Option<u64>,
 
+    /// Close server connections that have been opened for longer than this.
+    /// Only applied to idle connections. If the connection is actively used for
+    /// longer than this period, the pool will not interrupt it.
     pub server_lifetime: Option<u64>,
 
     #[serde(default = "Pool::default_sharding_function")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1079,7 +1079,10 @@ impl Config {
                     None => "default".to_string(),
                 }
             );
-            info!("[pool: {}] Cleanup server connections: {}", pool_name, pool_config.cleanup_server_connections);
+            info!(
+                "[pool: {}] Cleanup server connections: {}",
+                pool_name, pool_config.cleanup_server_connections
+            );
             info!(
                 "[pool: {}] Plugins: {}",
                 pool_name,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1079,6 +1079,7 @@ impl Config {
                     None => "default".to_string(),
                 }
             );
+            info!("[pool: {}] Cleanup server connections: {}", pool_name, pool_config.cleanup_server_connections);
             info!(
                 "[pool: {}] Plugins: {}",
                 pool_name,

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -44,6 +44,7 @@ impl MirroredClient {
             Arc::new(PoolStats::new(identifier, cfg.clone())),
             Arc::new(RwLock::new(None)),
             None,
+            true,
         );
 
         Pool::builder()

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -364,7 +364,7 @@ impl ConnectionPool {
                                 Some(ref plugins) => Some(plugins.clone()),
                                 None => config.plugins.clone(),
                             },
-                            config.general.cleanup_server_connections,
+                            pool_config.cleanup_server_connections,
                         );
 
                         let connect_timeout = match pool_config.connect_timeout {

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -118,7 +118,7 @@ module Helpers
       end
     end
 
-    def self.single_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info")
+    def self.single_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info", general_settings={})
       user = {
         "password" => "sharding_user",
         "pool_size" => pool_size,
@@ -158,6 +158,7 @@ module Helpers
         }
       }
       pgcat_cfg["general"]["port"] = pgcat.port
+      pgcat_cfg["general"].merge(general_settings)
       pgcat.update_config(pgcat_cfg)
       pgcat.start
       pgcat.wait_until_ready

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -118,7 +118,7 @@ module Helpers
       end
     end
 
-    def self.single_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info", general_settings={})
+    def self.single_shard_setup(pool_name, pool_size, pool_mode="transaction", lb_mode="random", log_level="info", pool_settings={})
       user = {
         "password" => "sharding_user",
         "pool_size" => pool_size,
@@ -157,8 +157,8 @@ module Helpers
           "users" => { "0" => user }
         }
       }
+      pgcat_cfg[pool_name].merge(pool_settings)
       pgcat_cfg["general"]["port"] = pgcat.port
-      pgcat_cfg["general"].merge(general_settings)
       pgcat.update_config(pgcat_cfg)
       pgcat.start
       pgcat.wait_until_ready

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -157,7 +157,7 @@ module Helpers
           "users" => { "0" => user }
         }
       }
-      pgcat_cfg[pool_name].merge(pool_settings)
+      pgcat_cfg["pools"][pool_name].merge(pool_settings)
       pgcat_cfg["general"]["port"] = pgcat.port
       pgcat.update_config(pgcat_cfg)
       pgcat.start

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -134,30 +134,33 @@ module Helpers
       replica1 = PgInstance.new(8432, user["username"], user["password"], "shard0")
       replica2 = PgInstance.new(9432, user["username"], user["password"], "shard0")
 
+      pool_config = {
+        "default_role" => "any",
+        "pool_mode" => pool_mode,
+        "load_balancing_mode" => lb_mode,
+        "primary_reads_enabled" => false,
+        "query_parser_enabled" => false,
+        "sharding_function" => "pg_bigint_hash",
+        "shards" => {
+          "0" => {
+            "database" => "shard0",
+            "servers" => [
+              ["localhost", primary.port.to_s, "primary"],
+              ["localhost", replica0.port.to_s, "replica"],
+              ["localhost", replica1.port.to_s, "replica"],
+              ["localhost", replica2.port.to_s, "replica"]
+            ]
+          },
+        },
+        "users" => { "0" => user }
+      }
+
+      pool_config = pool_config.merge(pool_settings)
+
       # Main proxy configs
       pgcat_cfg["pools"] = {
-        "#{pool_name}" => {
-          "default_role" => "any",
-          "pool_mode" => pool_mode,
-          "load_balancing_mode" => lb_mode,
-          "primary_reads_enabled" => false,
-          "query_parser_enabled" => false,
-          "sharding_function" => "pg_bigint_hash",
-          "shards" => {
-            "0" => {
-              "database" => "shard0",
-              "servers" => [
-                ["localhost", primary.port.to_s, "primary"],
-                ["localhost", replica0.port.to_s, "replica"],
-                ["localhost", replica1.port.to_s, "replica"],
-                ["localhost", replica2.port.to_s, "replica"]
-              ]
-            },
-          },
-          "users" => { "0" => user }
-        }
+        "#{pool_name}" => pool_config,
       }
-      pgcat_cfg["pools"][pool_name].merge(pool_settings)
       pgcat_cfg["general"]["port"] = pgcat.port
       pgcat.update_config(pgcat_cfg)
       pgcat.start

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -322,21 +322,26 @@ describe "Miscellaneous" do
     end
 
     context "server cleanup disabled" do
-      let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 1, "transaction", "random", "info", { "cleanup_server_connections": false }) }
+      let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 1, "transaction", "random", "info", { "cleanup_server_connections" => false }) }
 
       it "will not clean up connection state" do
         conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+        processes.primary.reset_stats
         conn.async_exec("SET statement_timeout TO 1000")
         conn.close
 
+        puts processes.pgcat.logs
         expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
       end
 
       it "will not clean up prepared statements" do
         conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+        processes.primary.reset_stats
         conn.async_exec("PREPARE prepared_q (int) AS SELECT $1")
+
         conn.close
 
+        puts processes.pgcat.logs
         expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
       end
     end


### PR DESCRIPTION
### Feature

We currently automatically remove prepared statements and set commands from servers if they are used in transaction mode. Sometimes though, applications rely on this not happening, e.g. if they were previously using PgBouncer. Making this optional with this setting. Defaults to `true`, so existing behavior is preserved.