### PR TITLE
Use latest bb8 and use Lifo as the queue strategy in the pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,8 +84,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "bb8"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1627eccf3aa91405435ba240be23513eeca466b5dc33866422672264de061582"
+source = "git+https://github.com/djc/bb8.git?rev=935b887#935b88781f3285040b20eb920f7dcfa3bd7533f0"
 dependencies = [
  "async-trait",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "bb8"
 version = "0.8.0"
-source = "git+https://github.com/djc/bb8.git?rev=935b887#935b88781f3285040b20eb920f7dcfa3bd7533f0"
+source = "git+https://github.com/djc/bb8.git?rev=ad653e0#ad653e021607eb1f90ed6ce554d1766920308ffa"
 dependencies = [
  "async-trait",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 md-5 = "0.10"
-bb8 = { git = "https://github.com/djc/bb8.git", rev = "935b887" }
+bb8 = { git = "https://github.com/djc/bb8.git", rev = "ad653e0" } # https://github.com/djc/bb8/commit/ad653e021607eb1f90ed6ce554d1766920308ffa
 async-trait = "0.1"
 rand = "0.8"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 md-5 = "0.10"
-bb8 = "0.8.0"
+bb8 = { git = "https://github.com/djc/bb8.git", rev = "935b887" }
 async-trait = "0.1"
 rand = "0.8"
 chrono = "0.4"

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,6 @@
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use bb8::{ManageConnection, Pool, PooledConnection};
+use bb8::{ManageConnection, Pool, PooledConnection, QueueStrategy};
 use bytes::{BufMut, BytesMut};
 use chrono::naive::NaiveDateTime;
 use log::{debug, error, info, warn};
@@ -401,6 +401,7 @@ impl ConnectionPool {
                             .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                             .max_lifetime(Some(std::time::Duration::from_millis(server_lifetime)))
                             .reaper_rate(std::time::Duration::from_millis(reaper_rate))
+                            .queue_strategy(QueueStrategy::Lifo)
                             .test_on_check_out(false);
 
                         let pool = if config.general.validate_config {


### PR DESCRIPTION
Use Lifo as the queue strategy for the pool so that we can try to keep the current pool size as small as possible