### PR TITLE
Change default server lifetime and bump bb8 version to use LIFO correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,8 +83,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bb8"
-version = "0.8.0"
-source = "git+https://github.com/djc/bb8.git?rev=ad653e0#ad653e021607eb1f90ed6ce554d1766920308ffa"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
 dependencies = [
  "async-trait",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 bytes = "1"
 md-5 = "0.10"
-bb8 = { git = "https://github.com/djc/bb8.git", rev = "ad653e0" } # https://github.com/djc/bb8/commit/ad653e021607eb1f90ed6ce554d1766920308ffa
+bb8 = "0.8.1"
 async-trait = "0.1"
 rand = "0.8"
 chrono = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,7 +329,7 @@ impl General {
     }
 
     pub fn default_server_lifetime() -> u64 {
-        1000 * 60 * 60 * 24 // 24 hours
+        1000 * 60 * 60 // 1 hour
     }
 
     pub fn default_connect_timeout() -> u64 {
@@ -352,7 +352,7 @@ impl General {
     }
 
     pub fn default_idle_timeout() -> u64 {
-        60000 // 10 minutes
+        60000 // 1 minute
     }
 
     pub fn default_shutdown_timeout() -> u64 {


### PR DESCRIPTION
24 hour server lifetime seems too long as a default, changing it to 1 hour to match pgbouncer
Recent patch to fix LIFO for bb8 in the latest release, this bumps the version