### PR TITLE
Make queue strategy configurable and default to Fifo

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -355,7 +355,7 @@ impl General {
     }
 
     pub fn default_idle_timeout() -> u64 {
-        600000 // 10 minutes
+        60000 // 10 minutes
     }
 
     pub fn default_shutdown_timeout() -> u64 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,9 @@ pub struct General {
     #[serde(default = "General::default_server_lifetime")]
     pub server_lifetime: u64,
 
+    #[serde(default = "General::default_server_round_robin")] // False
+    pub server_round_robin: bool,
+
     #[serde(default = "General::default_worker_threads")]
     pub worker_threads: usize,
 
@@ -390,6 +393,10 @@ impl General {
     pub fn default_prometheus_exporter_port() -> i16 {
         9930
     }
+
+    pub fn default_server_round_robin() -> bool {
+        true
+    }
 }
 
 impl Default for General {
@@ -424,7 +431,8 @@ impl Default for General {
             auth_query: None,
             auth_query_user: None,
             auth_query_password: None,
-            server_lifetime: 1000 * 3600 * 24, // 24 hours,
+            server_lifetime: Self::default_server_lifetime(),
+            server_round_robin: false,
             validate_config: true,
         }
     }
@@ -983,6 +991,7 @@ impl Config {
             "Default max server lifetime: {}ms",
             self.general.server_lifetime
         );
+        info!("Sever round robin: {}", self.general.server_round_robin);
         match self.general.tls_certificate.clone() {
             Some(tls_certificate) => {
                 info!("TLS certificate: {}", tls_certificate);

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,7 +355,7 @@ impl General {
     }
 
     pub fn default_idle_timeout() -> u64 {
-        60000 // 10 minutes
+        600000 // 10 minutes
     }
 
     pub fn default_shutdown_timeout() -> u64 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,7 +352,7 @@ impl General {
     }
 
     pub fn default_idle_timeout() -> u64 {
-        60000 // 1 minute
+        600000 // 10 minutes
     }
 
     pub fn default_shutdown_timeout() -> u64 {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,6 @@
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use bb8::{ManageConnection, Pool, PooledConnection, QueueStrategy};
+use bb8::{ManageConnection, Pool, PooledConnection};
 use bytes::{BufMut, BytesMut};
 use chrono::naive::NaiveDateTime;
 use log::{debug, error, info, warn};
@@ -401,7 +401,6 @@ impl ConnectionPool {
                             .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                             .max_lifetime(Some(std::time::Duration::from_millis(server_lifetime)))
                             .reaper_rate(std::time::Duration::from_millis(reaper_rate))
-                            .queue_strategy(QueueStrategy::Lifo)
                             .test_on_check_out(false);
 
                         let pool = if config.general.validate_config {

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -63,6 +63,7 @@ def cleanup_conn(conn: psycopg2.extensions.connection, cur: psycopg2.extensions.
 
 
 def test_normal_db_access():
+    pgcat_start()
     conn, cur = connect_db(autocommit=False)
     cur.execute("SELECT 1")
     res = cur.fetchall()


### PR DESCRIPTION
We noticed some connection thrashing issues with using PgCat and Lifo, defaulting to using Fifo (default of bb8) and making  the option configurable

The idle timeout was incorrectly commented as 10 minutes before but actually set to 1 minute. A previous PR of mine fixed the comment but it seems that a value of 10 minutes is a better default for this timeout (same as pgbouncer)