### PR TITLE
Log not implemented messages as debug in prometheus metrics.

### DIFF
--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,6 +1,6 @@
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
-use log::{error, info, warn};
+use log::{error, info, debug};
 use phf::phf_map;
 use std::collections::HashMap;
 use std::fmt;
@@ -275,7 +275,7 @@ fn push_address_stats(lines: &mut Vec<String>) {
                     {
                         lines.push(prometheus_metric.to_string());
                     } else {
-                        warn!("Metric {} not implemented for {}", key, address.name());
+                        debug!("Metric {} not implemented for {}", key, address.name());
                     }
                 }
             }
@@ -293,7 +293,7 @@ fn push_pool_stats(lines: &mut Vec<String>) {
             {
                 lines.push(prometheus_metric.to_string());
             } else {
-                warn!("Metric {} not implemented for ({})", name, *pool_id);
+                debug!("Metric {} not implemented for ({})", name, *pool_id);
             }
         }
     }
@@ -318,7 +318,7 @@ fn push_database_stats(lines: &mut Vec<String>) {
                     {
                         lines.push(prometheus_metric.to_string());
                     } else {
-                        warn!("Metric {} not implemented for {}", key, address.name());
+                        debug!("Metric {} not implemented for {}", key, address.name());
                     }
                 }
             }


### PR DESCRIPTION
Logging this as `warn` brings a lot of noise and is impossible to exclude since in prod you want to be running at least with INFO.