### PR TITLE
Implement Close for prepared statements

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -63,6 +63,9 @@ tcp_keepalives_interval = 5
 # Handle prepared statements.
 prepared_statements = true
 
+# Prepared statements server cache size.
+prepared_statements_cache_size = 500
+
 # Path to TLS Certificate file to use for TLS connections
 # tls_certificate = ".circleci/server.cert"
 # Path to TLS private key file to use for TLS connections

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -701,6 +701,7 @@ where
         ("age_seconds", DataType::Numeric),
         ("prepare_cache_hit", DataType::Numeric),
         ("prepare_cache_miss", DataType::Numeric),
+        ("prepare_cache_size", DataType::Numeric),
     ];
 
     let new_map = get_server_stats();
@@ -730,6 +731,10 @@ where
                 .to_string(),
             server
                 .prepared_miss_count
+                .load(Ordering::Relaxed)
+                .to_string(),
+            server
+                .prepared_cache_size
                 .load(Ordering::Relaxed)
                 .to_string(),
         ];

--- a/src/client.rs
+++ b/src/client.rs
@@ -1476,11 +1476,12 @@ where
             // The server is no longer bound to us, we can't cancel it's queries anymore.
             debug!("Releasing server back into the pool");
 
+            server.checkin_cleanup().await?;
+
             if prepared_statements_enabled {
                 server.maintain_cache().await?;
             }
 
-            server.checkin_cleanup().await?;
             server.stats().idle();
             self.connected_to_server = false;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1028,6 +1028,12 @@ impl Config {
             self.general.verify_server_certificate
         );
         info!("Prepared statements: {}", self.general.prepared_statements);
+        if self.general.prepared_statements {
+            info!(
+                "Prepared statements server cache size: {}",
+                self.general.prepared_statements_cache_size
+            );
+        }
         info!(
             "Plugins: {}",
             match self.plugins {

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,6 +323,9 @@ pub struct General {
 
     #[serde(default)]
     pub prepared_statements: bool,
+
+    #[serde(default = "General::default_prepared_statements_cache_size")]
+    pub prepared_statements_cache_size: usize,
 }
 
 impl General {
@@ -400,6 +403,10 @@ impl General {
     pub fn default_server_round_robin() -> bool {
         true
     }
+
+    pub fn default_prepared_statements_cache_size() -> usize {
+        500
+    }
 }
 
 impl Default for General {
@@ -438,6 +445,7 @@ impl Default for General {
             server_round_robin: false,
             validate_config: true,
             prepared_statements: false,
+            prepared_statements_cache_size: 500,
         }
     }
 }
@@ -1239,13 +1247,15 @@ pub fn get_config() -> Config {
 }
 
 pub fn get_idle_client_in_transaction_timeout() -> u64 {
-    (*(*CONFIG.load()))
-        .general
-        .idle_client_in_transaction_timeout
+    CONFIG.load().general.idle_client_in_transaction_timeout
 }
 
 pub fn get_prepared_statements() -> bool {
-    (*(*CONFIG.load())).general.prepared_statements
+    CONFIG.load().general.prepared_statements
+}
+
+pub fn get_prepared_statements_cache_size() -> usize {
+    CONFIG.load().general.prepared_statements_cache_size
 }
 
 /// Parse the configuration file located at the path.

--- a/src/server.rs
+++ b/src/server.rs
@@ -914,12 +914,15 @@ impl Server {
         Ok(bytes)
     }
 
+    /// Add the prepared statement to being tracked by this server.
+    /// The client is processing data that will create a prepared statement on this server.
     pub fn will_prepare(&mut self, name: &str) {
         debug!("Will prepare `{}`", name);
 
         self.prepared_statements.insert(name.to_string());
     }
 
+    /// Check if we should prepare a statement on the server.
     pub fn should_prepare(&self, name: &str) -> bool {
         let should_prepare = !self.prepared_statements.contains(name);
 
@@ -934,6 +937,7 @@ impl Server {
         should_prepare
     }
 
+    /// Create a prepared statement on the server.
     pub async fn prepare(&mut self, parse: &Parse) -> Result<(), Error> {
         debug!("Preparing `{}`", parse.name);
 
@@ -949,6 +953,14 @@ impl Server {
         debug!("Prepared `{}`", parse.name);
 
         Ok(())
+    }
+
+    /// Remove the prepared statement from being tracked by this server.
+    /// The client is processing data that will cause the server to close the prepared statement.
+    pub fn will_close(&mut self, name: &str) {
+        debug!("Will close `{}`", name);
+
+        self.prepared_statements.remove(name);
     }
 
     /// If the server is still inside a transaction.

--- a/src/stats/server.rs
+++ b/src/stats/server.rs
@@ -49,6 +49,7 @@ pub struct ServerStats {
     pub error_count: Arc<AtomicU64>,
     pub prepared_hit_count: Arc<AtomicU64>,
     pub prepared_miss_count: Arc<AtomicU64>,
+    pub prepared_cache_size: Arc<AtomicU64>,
 }
 
 impl Default for ServerStats {
@@ -67,6 +68,7 @@ impl Default for ServerStats {
             reporter: get_reporter(),
             prepared_hit_count: Arc::new(AtomicU64::new(0)),
             prepared_miss_count: Arc::new(AtomicU64::new(0)),
+            prepared_cache_size: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -212,5 +214,13 @@ impl ServerStats {
     /// Report a prepared statement that does not exist on the server yet.
     pub fn prepared_cache_miss(&self) {
         self.prepared_miss_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn prepared_cache_add(&self) {
+        self.prepared_cache_size.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn prepared_cache_remove(&self) {
+        self.prepared_cache_size.fetch_sub(1, Ordering::Relaxed);
     }
 }

--- a/tests/ruby/prepared_spec.rb
+++ b/tests/ruby/prepared_spec.rb
@@ -1,0 +1,29 @@
+require_relative 'spec_helper'
+
+describe 'Prepared statements' do
+  let(:processes) { Helpers::Pgcat.three_shard_setup('sharded_db', 5) }
+
+  context 'enabled' do
+    it 'will work over the same connection' do
+      conn = PG.connect(processes.pgcat.connection_string('sharded_db', 'sharding_user'))
+
+      10.times do |i|
+        statement_name = "statement_#{i}"
+        conn.prepare(statement_name, 'SELECT $1::int')
+        conn.exec_prepared(statement_name, [1])
+        conn.describe_prepared(statement_name)
+      end
+    end
+
+    it 'will work with new connections' do
+      10.times do
+        conn = PG.connect(processes.pgcat.connection_string('sharded_db', 'sharding_user'))
+
+        statement_name = 'statement1'
+        conn.prepare('statement1', 'SELECT $1::int')
+        conn.exec_prepared('statement1', [1])
+        conn.describe_prepared('statement1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Features

Add support for `Close (F)`. In transaction mode, the prepared statement will be removed from the client cache, but not from the server cache. In session mode, the prepared statement will be removed from both server and client caches and from the Postgres server itself.

Add prepared statement cache size limit, with a cleanup job that removes statements that are above cache size. Cost of removal is amortized across clients, not ran as a maintenance loop out of connection lifetime. We need to write our own internal pool implementation to add the ability to run maintenance on connections out of usage scope. I think the impact at the moment will be mostly negligible because cache eviction should only be active on very active systems that are constantly used, so running a cleanup job out of client usage scope will still block the connection when it's needed.

### Bugs

Fixed what may have been a big latency bottleneck caused by incorrect `arc_swap` usage to fetch the idle in transaction config value.