### PR TITLE
fix pgcat.toml to handle autoreload 

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -48,7 +48,7 @@ log_client_connections = false
 log_client_disconnections = false
 
 # When set to true, PgCat reloads configs if it detects a change in the config file.
-autoreload = 15000
+autoreload = false
 
 # Number of worker threads the Runtime will use (4 by default).
 worker_threads = 5


### PR DESCRIPTION
autoreload is boolean , setting it to false

```
[2023-07-07T02:52:23.364883Z ERROR pgcat::config] Could not parse config file: TOML parse error at line 51, column 14
       |
    51 | autoreload = 15000
       |              ^^^^^
    invalid type: integer `15000`, expected a boolean
```