### PR TITLE
Add support for tcp_user_timeout

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,4 +1,4 @@
-# PgCat Configurations 
+# PgCat Configurations
 ## `general` Section
 
 ### host
@@ -151,7 +151,13 @@ path: general.tcp_keepalives_interval
 default: 5
 ```
 
-Number of seconds between keepalive packets.
+### tcp_user_timeout
+```
+path: general.tcp_user_timeout
+default: 10000
+```
+A linux-only parameters that defines the amount of time in milliseconds that transmitted data may remain unacknowledged or buffered data may remain untransmitted (due to zero window size) before TCP will forcibly disconnect
+
 
 ### tls_certificate
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -416,6 +416,7 @@ impl Default for General {
             tcp_keepalives_idle: Self::default_tcp_keepalives_idle(),
             tcp_keepalives_count: Self::default_tcp_keepalives_count(),
             tcp_keepalives_interval: Self::default_tcp_keepalives_interval(),
+            tcp_user_timeout: Self::default_tcp_user_timeout(),
             log_client_connections: false,
             log_client_disconnections: false,
             autoreload: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,6 +261,8 @@ pub struct General {
     pub tcp_keepalives_count: u32,
     #[serde(default = "General::default_tcp_keepalives_interval")]
     pub tcp_keepalives_interval: u64,
+    #[serde(default = "General::default_tcp_user_timeout")]
+    pub tcp_user_timeout: u64,
 
     #[serde(default)] // False
     pub log_client_connections: bool,
@@ -349,6 +351,10 @@ impl General {
 
     pub fn default_tcp_keepalives_interval() -> u64 {
         5 // 5 seconds
+    }
+
+    pub fn default_tcp_user_timeout() -> u64 {
+        10000 // 10000 milliseconds
     }
 
     pub fn default_idle_timeout() -> u64 {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -661,7 +661,7 @@ pub fn configure_socket(stream: &TcpStream) {
     match sock_ref.set_keepalive(true) {
         Ok(_) => {
             #[cfg(target_os = "linux")]
-            sock_ref.set_tcp_user_timeout(10).unwrap();
+            sock_ref.set_tcp_user_timeout(Some(10)).unwrap();
             match sock_ref.set_tcp_keepalive(
                 &TcpKeepalive::new()
                     .with_interval(Duration::from_secs(conf.general.tcp_keepalives_interval))

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -658,14 +658,14 @@ pub fn configure_socket(stream: &TcpStream) {
     let sock_ref = SockRef::from(stream);
     let conf = get_config();
 
+    #[cfg(target_os = "linux")]
+    match sock_ref.set_tcp_user_timeout(Some(Duration::from_millis(1000))) {
+        Ok(_) => (),
+        Err(err) => error!("Could not configure tcp_user_timeout for socket: {}", err),
+    }
+
     match sock_ref.set_keepalive(true) {
         Ok(_) => {
-            #[cfg(target_os = "linux")]
-            match sock_ref.set_tcp_user_timeout(Duration::from_millis(1000)) {
-                Ok(_) => (),
-                Err(err) => error!("Could not configure tcp_user_timeout for socket: {}", err),
-            }
-
             match sock_ref.set_tcp_keepalive(
                 &TcpKeepalive::new()
                     .with_interval(Duration::from_secs(conf.general.tcp_keepalives_interval))

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -661,7 +661,11 @@ pub fn configure_socket(stream: &TcpStream) {
     match sock_ref.set_keepalive(true) {
         Ok(_) => {
             #[cfg(target_os = "linux")]
-            sock_ref.set_tcp_user_timeout(Some(10)).unwrap();
+            match sock_ref.set_tcp_user_timeout(Duration::from_millis(1000)) {
+                Ok(_) => (),
+                Err(err) => error!("Could not configure tcp_user_timeout for socket: {}", err),
+            }
+
             match sock_ref.set_tcp_keepalive(
                 &TcpKeepalive::new()
                     .with_interval(Duration::from_secs(conf.general.tcp_keepalives_interval))
@@ -669,7 +673,7 @@ pub fn configure_socket(stream: &TcpStream) {
                     .with_time(Duration::from_secs(conf.general.tcp_keepalives_idle)),
             ) {
                 Ok(_) => (),
-                Err(err) => error!("Could not configure socket: {}", err),
+                Err(err) => error!("Could not configure tcp_keepalive for socket: {}", err),
             }
         }
         Err(err) => error!("Could not configure socket: {}", err),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -659,7 +659,7 @@ pub fn configure_socket(stream: &TcpStream) {
     let conf = get_config();
 
     #[cfg(target_os = "linux")]
-    match sock_ref.set_tcp_user_timeout(Some(Duration::from_millis(1000))) {
+    match sock_ref.set_tcp_user_timeout(Some(Duration::from_millis(conf.general.tcp_user_timeout))) {
         Ok(_) => (),
         Err(err) => error!("Could not configure tcp_user_timeout for socket: {}", err),
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -659,7 +659,8 @@ pub fn configure_socket(stream: &TcpStream) {
     let conf = get_config();
 
     #[cfg(target_os = "linux")]
-    match sock_ref.set_tcp_user_timeout(Some(Duration::from_millis(conf.general.tcp_user_timeout))) {
+    match sock_ref.set_tcp_user_timeout(Some(Duration::from_millis(conf.general.tcp_user_timeout)))
+    {
         Ok(_) => (),
         Err(err) => error!("Could not configure tcp_user_timeout for socket: {}", err),
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -660,6 +660,8 @@ pub fn configure_socket(stream: &TcpStream) {
 
     match sock_ref.set_keepalive(true) {
         Ok(_) => {
+            #[cfg(target_os = "linux")]
+            sock_ref.set_tcp_user_timeout(10).unwrap();
             match sock_ref.set_tcp_keepalive(
                 &TcpKeepalive::new()
                     .with_interval(Duration::from_secs(conf.general.tcp_keepalives_interval))


### PR DESCRIPTION
`TCP_USER_TIMEOUT` is a quite powerful tool for managing TCP timeouts. It is a bit complex in how it behaves but it is currently the only real way for controlling the number of retransmits an active socket makes before giving up and timing out. Without this parameter set on the socket, we fallback to the OS default `tcp_retries2` parameter which generally keeps retrying for about 15 minutes before declaring the connection dead. 

using `TCP_USER_TIMEOUT` with keepalive parameter ensures that we detect bad connections early and clean them up before we exhaust our pools and lock up the proxy.

Docs:
https://man7.org/linux/man-pages/man7/tcp.7.html
https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die/
https://tech.instacart.com/the-vanishing-thread-and-postgresql-tcp-connection-parameters-93afc0e1208c