### PR TITLE
add "show help" command

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -530,6 +530,26 @@ pub fn command_complete(command: &str) -> BytesMut {
     res
 }
 
+/// Create a notify message.
+pub fn notify(message: &str, details: String) -> BytesMut {
+    let mut notify_cmd = BytesMut::new();
+
+    notify_cmd.put_slice("SNOTICE\0".as_bytes());
+    notify_cmd.put_slice("C00000\0".as_bytes());
+    notify_cmd.put_slice(format!("M{}\0", message).as_bytes());
+    notify_cmd.put_slice(format!("D{}\0", details).as_bytes());
+
+    // this extra byte says that is the end of the package
+    notify_cmd.put_u8(0);
+
+    let mut res = BytesMut::new();
+    res.put_u8(b'N');
+    res.put_i32(notify_cmd.len() as i32 + 4);
+    res.put(notify_cmd);
+
+    res
+}
+
 pub fn flush() -> BytesMut {
     let mut bytes = BytesMut::new();
     bytes.put_u8(b'H');


### PR DESCRIPTION
Hey Everyone, I'm new to Rust and this is an attempt to implement the `show help` command.

Currently, it has a bug in the package that I'm trying to figure out:

```
❯ PGPASSWORD=postgres psql -h 127.0.0.1 -p 6432 -U postgres pgbouncer -c 'show help';
NOTICE:  Console usage
DETAIL:
	SHOW HELP|CONFIG|DATABASES|POOLS|CLIENTS|SERVERS|USERS|VERSION
	SHOW LISTS
	SHOW STATS
	SET key = arg
	RELOAD
	PAUSE [<db>, <user>]
	RESUME [<db>, <user>]
	SHUTDOWN
message contents do not agree with length in message type "N"
SHOW
```

I've understood that pgcat is a replacement for pgbouncer, so I copied the help in the same format as pgbouncer does in [`admin.c`](https://github.com/pgbouncer/pgbouncer/blob/master/src/admin.c#L1408-L1434).

Currently trying to figure what is the cause of the error below:

```
message contents do not agree with length in message type "N"
```