### PR TITLE
push and build only in main and tags

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,6 +1,11 @@
 name: Build and Push
 
-on: push
+on:
+  push:
+    branches:    
+      - main
+    tags:
+      - v*
 
 env:
   registry: ghcr.io


### PR DESCRIPTION
this commit changes the CI behavior to only build and push when something is committed to main or is a new tag.