### PR TITLE
add `--no-color` option to disable colors in the terminal

### DIFF
--- a/src/cmd_args.rs
+++ b/src/cmd_args.rs
@@ -13,6 +13,15 @@ pub struct Args {
 
     #[clap(short='F', long, value_enum, default_value_t=LogFormat::Text, env)]
     pub log_format: LogFormat,
+
+    #[arg(
+        short,
+        long,
+        default_value_t = false,
+        env,
+        help = "disable colors in the log output"
+    )]
+    pub no_color: bool,
 }
 
 pub fn parse() -> Args {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod constants;
 pub mod dns_cache;
 pub mod errors;
+pub mod logger;
 pub mod messages;
 pub mod mirrors;
 pub mod plugins;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,14 @@
+use crate::cmd_args::{Args, LogFormat};
+use tracing_subscriber;
+
+pub fn init(args: &Args) {
+    let trace_sub = tracing_subscriber::fmt()
+        .with_max_level(args.log_level)
+        .with_ansi(!args.no_color);
+
+    match args.log_format {
+        LogFormat::Structured => trace_sub.json().init(),
+        LogFormat::Debug => trace_sub.pretty().init(),
+        _ => trace_sub.init(),
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,30 +62,17 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use pgcat::cmd_args;
-use pgcat::cmd_args::LogFormat;
 use pgcat::config::{get_config, reload_config, VERSION};
 use pgcat::dns_cache;
+use pgcat::logger;
 use pgcat::messages::configure_socket;
 use pgcat::pool::{ClientServerMap, ConnectionPool};
 use pgcat::prometheus::start_metric_server;
 use pgcat::stats::{Collector, Reporter, REPORTER};
-use tracing_subscriber;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cmd_args::parse();
-    match args.log_format {
-        LogFormat::Structured => tracing_subscriber::fmt()
-            .json()
-            .with_max_level(args.log_level)
-            .init(),
-        LogFormat::Debug => tracing_subscriber::fmt()
-            .pretty()
-            .with_max_level(args.log_level)
-            .init(),
-        _ => tracing_subscriber::fmt()
-            .with_max_level(args.log_level)
-            .init(),
-    };
+    logger::init(&args);
 
     info!("Welcome to PgCat! Meow. (Version {})", VERSION);
 


### PR DESCRIPTION
added another option to disable colors - if needed:

```
❯ cargo run -- --help                                                          
    Finished dev [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/pgcat --help`
PgCat: Nextgen PostgreSQL Pooler

Usage: pgcat [OPTIONS] [CONFIG_FILE]

Arguments:
  [CONFIG_FILE]  [env: CONFIG_FILE=] [default: pgcat.toml]

Options:
  -l, --log-level <LOG_LEVEL>    [env: LOG_LEVEL=] [default: INFO]
  -F, --log-format <LOG_FORMAT>  [env: LOG_FORMAT=] [default: text] [possible values: text, structured, debug]
  -n, --no-color                 disable colors in the log output [env: NO_COLOR=]
  -h, --help                     Print help
  -V, --version                  Print version

```

Also moved the tracing stuff to a separate crate.