### PR TITLE
Make infer role configurable and fix double parse bug

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -74,6 +74,10 @@ default_role = "any"
 # we'll direct it to the primary.
 query_parser_enabled = true
 
+# If the query parser is enabled and this setting is enabled, we'll attempt to
+# infer the role from the query itself.
+infer_role_from_query = true
+
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write
 # queries. The primary can always be explicitely selected with our custom protocol.
@@ -134,6 +138,7 @@ database = "shard2"
 pool_mode = "session"
 default_role = "primary"
 query_parser_enabled = true
+infer_role_from_query = true
 primary_reads_enabled = true
 sharding_function = "pg_bigint_hash"
 

--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -76,7 +76,7 @@ query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, we'll attempt to
 # infer the role from the query itself.
-infer_role_from_query = true
+query_parser_read_write_splitting = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write
@@ -138,7 +138,7 @@ database = "shard2"
 pool_mode = "session"
 default_role = "primary"
 query_parser_enabled = true
-infer_role_from_query = true
+query_parser_read_write_splitting = true
 primary_reads_enabled = true
 sharding_function = "pg_bigint_hash"
 

--- a/examples/docker/pgcat.toml
+++ b/examples/docker/pgcat.toml
@@ -73,7 +73,7 @@ query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, we'll attempt to
 # infer the role from the query itself.
-infer_role_from_query = true
+query_parser_read_write_splitting = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write

--- a/examples/docker/pgcat.toml
+++ b/examples/docker/pgcat.toml
@@ -71,6 +71,10 @@ default_role = "any"
 # we'll direct it to the primary.
 query_parser_enabled = true
 
+# If the query parser is enabled and this setting is enabled, we'll attempt to
+# infer the role from the query itself.
+infer_role_from_query = true
+
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write
 # queries. The primary can always be explicitly selected with our custom protocol.

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -164,7 +164,7 @@ query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, we'll attempt to
 # infer the role from the query itself.
-infer_role_from_query = true
+query_parser_read_write_splitting = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -162,6 +162,10 @@ default_role = "any"
 # we'll direct it to the primary.
 query_parser_enabled = true
 
+# If the query parser is enabled and this setting is enabled, we'll attempt to
+# infer the role from the query itself.
+infer_role_from_query = true
+
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write
 # queries. The primary can always be explicitly selected with our custom protocol.

--- a/src/client.rs
+++ b/src/client.rs
@@ -774,6 +774,9 @@ where
         let mut prepared_statement = None;
         let mut will_prepare = false;
 
+        let client_identifier =
+            ClientIdentifier::new(&self.application_name, &self.username, &self.pool_name);
+
         // Our custom protocol loop.
         // We expect the client to either start a transaction with regular queries
         // or issue commands for our sharding and server selection protocol.
@@ -856,26 +859,34 @@ where
 
                 'Q' => {
                     if query_router.query_parser_enabled() {
-                        if let Ok(ast) = QueryRouter::parse(&message) {
-                            let plugin_result = query_router.execute_plugins(&ast).await;
+                        match query_router.parse(&message) {
+                            Ok(ast) => {
+                                let plugin_result = query_router.execute_plugins(&ast).await;
 
-                            match plugin_result {
-                                Ok(PluginOutput::Deny(error)) => {
-                                    error_response(&mut self.write, &error).await?;
-                                    continue;
-                                }
+                                match plugin_result {
+                                    Ok(PluginOutput::Deny(error)) => {
+                                        error_response(&mut self.write, &error).await?;
+                                        continue;
+                                    }
 
-                                Ok(PluginOutput::Intercept(result)) => {
-                                    write_all(&mut self.write, result).await?;
-                                    continue;
-                                }
+                                    Ok(PluginOutput::Intercept(result)) => {
+                                        write_all(&mut self.write, result).await?;
+                                        continue;
+                                    }
 
-                                _ => (),
-                            };
+                                    _ => (),
+                                };
 
-                            let _ = query_router.infer(&ast);
+                                let _ = query_router.infer(&ast);
 
-                            initial_parsed_ast = Some(ast);
+                                initial_parsed_ast = Some(ast);
+                            }
+                            Err(error) => {
+                                warn!(
+                                    "Query parsing error: {} (client: {})",
+                                    error, client_identifier
+                                );
+                            }
                         }
                     }
                 }
@@ -889,13 +900,21 @@ where
                     self.buffer.put(&message[..]);
 
                     if query_router.query_parser_enabled() {
-                        if let Ok(ast) = QueryRouter::parse(&message) {
-                            if let Ok(output) = query_router.execute_plugins(&ast).await {
-                                plugin_output = Some(output);
-                            }
+                        match query_router.parse(&message) {
+                            Ok(ast) => {
+                                if let Ok(output) = query_router.execute_plugins(&ast).await {
+                                    plugin_output = Some(output);
+                                }
 
-                            let _ = query_router.infer(&ast);
-                        }
+                                let _ = query_router.infer(&ast);
+                            }
+                            Err(error) => {
+                                warn!(
+                                    "Query parsing error: {} (client: {})",
+                                    error, client_identifier
+                                );
+                            }
+                        };
                     }
 
                     continue;
@@ -1231,11 +1250,20 @@ where
                         if query_router.query_parser_enabled() {
                             // We don't want to parse again if we already parsed it as the initial message
                             let ast = match initial_parsed_ast {
-                                Some(_) => Ok(initial_parsed_ast.take().unwrap()),
-                                None => QueryRouter::parse(&message),
+                                Some(_) => Some(initial_parsed_ast.take().unwrap()),
+                                None => match query_router.parse(&message) {
+                                    Ok(ast) => Some(ast),
+                                    Err(error) => {
+                                        warn!(
+                                            "Query parsing error: {} (client: {})",
+                                            error, client_identifier
+                                        );
+                                        None
+                                    }
+                                },
                             };
 
-                            if let Ok(ast) = ast {
+                            if let Some(ast) = ast {
                                 let plugin_result = query_router.execute_plugins(&ast).await;
 
                                 match plugin_result {
@@ -1302,7 +1330,7 @@ where
                         }
 
                         if query_router.query_parser_enabled() {
-                            if let Ok(ast) = QueryRouter::parse(&message) {
+                            if let Ok(ast) = query_router.parse(&message) {
                                 if let Ok(output) = query_router.execute_plugins(&ast).await {
                                     plugin_output = Some(output);
                                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -937,7 +937,7 @@ impl From<&Config> for std::collections::HashMap<String, String> {
                         format!("pools.{}.query_parser_max_length", pool_name),
                         match pool.query_parser_max_length {
                             Some(max_length) => max_length.to_string(),
-                            None => String::from("None"),
+                            None => String::from("unlimited"),
                         },
                     ),
                     (

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -465,7 +465,8 @@ impl ConnectionPool {
                         },
                         query_parser_enabled: pool_config.query_parser_enabled,
                         query_parser_max_length: pool_config.query_parser_max_length,
-                        query_parser_read_write_splitting: pool_config.query_parser_read_write_splitting,
+                        query_parser_read_write_splitting: pool_config
+                            .query_parser_read_write_splitting,
                         primary_reads_enabled: pool_config.primary_reads_enabled,
                         sharding_function: pool_config.sharding_function,
                         automatic_sharding_key: pool_config.automatic_sharding_key.clone(),

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -111,6 +111,9 @@ pub struct PoolSettings {
     // Enable/disable query parser.
     pub query_parser_enabled: bool,
 
+    // Infer role
+    pub infer_role_from_query: bool,
+
     // Read from the primary as well or not.
     pub primary_reads_enabled: bool,
 
@@ -157,6 +160,7 @@ impl Default for PoolSettings {
             db: String::default(),
             default_role: None,
             query_parser_enabled: false,
+            infer_role_from_query: false,
             primary_reads_enabled: true,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: None,
@@ -456,6 +460,7 @@ impl ConnectionPool {
                             _ => unreachable!(),
                         },
                         query_parser_enabled: pool_config.query_parser_enabled,
+                        infer_role_from_query: pool_config.infer_role_from_query,
                         primary_reads_enabled: pool_config.primary_reads_enabled,
                         sharding_function: pool_config.sharding_function,
                         automatic_sharding_key: pool_config.automatic_sharding_key.clone(),

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -111,8 +111,11 @@ pub struct PoolSettings {
     // Enable/disable query parser.
     pub query_parser_enabled: bool,
 
+    // Max length of query the parser will parse.
+    pub query_parser_max_length: Option<usize>,
+
     // Infer role
-    pub infer_role_from_query: bool,
+    pub query_parser_read_write_splitting: bool,
 
     // Read from the primary as well or not.
     pub primary_reads_enabled: bool,
@@ -160,7 +163,8 @@ impl Default for PoolSettings {
             db: String::default(),
             default_role: None,
             query_parser_enabled: false,
-            infer_role_from_query: false,
+            query_parser_max_length: None,
+            query_parser_read_write_splitting: false,
             primary_reads_enabled: true,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: None,
@@ -460,7 +464,8 @@ impl ConnectionPool {
                             _ => unreachable!(),
                         },
                         query_parser_enabled: pool_config.query_parser_enabled,
-                        infer_role_from_query: pool_config.infer_role_from_query,
+                        query_parser_max_length: pool_config.query_parser_max_length,
+                        query_parser_read_write_splitting: pool_config.query_parser_read_write_splitting,
                         primary_reads_enabled: pool_config.primary_reads_enabled,
                         sharding_function: pool_config.sharding_function,
                         automatic_sharding_key: pool_config.automatic_sharding_key.clone(),

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -437,6 +437,10 @@ impl QueryRouter {
     /// N.B.: Only supports anonymous prepared statements since we don't
     /// keep a cache of them in PgCat.
     pub fn infer_shard_from_bind(&mut self, message: &BytesMut) -> bool {
+        if !self.pool_settings.infer_role_from_query {
+            return false; // Nothing to do
+        }
+
         debug!("Parsing bind message");
 
         let mut message_cursor = Cursor::new(message);

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -914,6 +914,7 @@ mod test {
     fn test_infer_replica() {
         QueryRouter::setup();
         let mut qr = QueryRouter::new();
+        qr.pool_settings.infer_role_from_query = true;
         assert!(qr.try_execute_command(&simple_query("SET SERVER ROLE TO 'auto'")) != None);
         assert!(qr.query_parser_enabled());
 
@@ -938,6 +939,7 @@ mod test {
     fn test_infer_primary() {
         QueryRouter::setup();
         let mut qr = QueryRouter::new();
+        qr.pool_settings.infer_role_from_query = true;
 
         let queries = vec![
             simple_query("UPDATE items SET name = 'pumpkin' WHERE id = 5"),
@@ -968,6 +970,8 @@ mod test {
     fn test_infer_parse_prepared() {
         QueryRouter::setup();
         let mut qr = QueryRouter::new();
+        qr.pool_settings.infer_role_from_query = true;
+
         qr.try_execute_command(&simple_query("SET SERVER ROLE TO 'auto'"));
         assert!(qr.try_execute_command(&simple_query("SET PRIMARY READS TO off")) != None);
 
@@ -1136,6 +1140,8 @@ mod test {
     fn test_enable_query_parser() {
         QueryRouter::setup();
         let mut qr = QueryRouter::new();
+        qr.pool_settings.infer_role_from_query = true;
+
         let query = simple_query("SET SERVER ROLE TO 'auto'");
         assert!(qr.try_execute_command(&simple_query("SET PRIMARY READS TO off")) != None);
 
@@ -1168,7 +1174,7 @@ mod test {
             user: crate::config::User::default(),
             default_role: Some(Role::Replica),
             query_parser_enabled: true,
-            infer_role_from_query: false,
+            infer_role_from_query: true,
             primary_reads_enabled: false,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: Some(String::from("test.id")),
@@ -1244,7 +1250,7 @@ mod test {
             user: crate::config::User::default(),
             default_role: Some(Role::Replica),
             query_parser_enabled: true,
-            infer_role_from_query: false,
+            infer_role_from_query: true,
             primary_reads_enabled: false,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: None,
@@ -1290,6 +1296,7 @@ mod test {
         let mut qr = QueryRouter::new();
         qr.pool_settings.automatic_sharding_key = Some("data.id".to_string());
         qr.pool_settings.shards = 3;
+        qr.pool_settings.infer_role_from_query = true;
 
         assert!(qr
             .infer(&QueryRouter::parse(&simple_query("SELECT * FROM data WHERE id = 5")).unwrap())
@@ -1391,6 +1398,7 @@ mod test {
         let mut qr = QueryRouter::new();
         qr.pool_settings.automatic_sharding_key = Some("data.id".to_string());
         qr.pool_settings.shards = 3;
+        qr.pool_settings.infer_role_from_query = true;
 
         assert!(qr
             .infer(&QueryRouter::parse(&simple_query(stmt)).unwrap())

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -372,6 +372,10 @@ impl QueryRouter {
 
     /// Try to infer which server to connect to based on the contents of the query.
     pub fn infer(&mut self, ast: &Vec<sqlparser::ast::Statement>) -> Result<(), Error> {
+        if !self.pool_settings.infer_role_from_query {
+            return Ok(()); // Nothing to do
+        }
+
         debug!("Inferring role");
 
         if ast.is_empty() {
@@ -1164,6 +1168,7 @@ mod test {
             user: crate::config::User::default(),
             default_role: Some(Role::Replica),
             query_parser_enabled: true,
+            infer_role_from_query: false,
             primary_reads_enabled: false,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: Some(String::from("test.id")),
@@ -1239,6 +1244,7 @@ mod test {
             user: crate::config::User::default(),
             default_role: Some(Role::Replica),
             query_parser_enabled: true,
+            infer_role_from_query: false,
             primary_reads_enabled: false,
             sharding_function: ShardingFunction::PgBigintHash,
             automatic_sharding_key: None,

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -34,7 +34,7 @@ module Helpers
           "load_balancing_mode" => lb_mode,
           "primary_reads_enabled" => true,
           "query_parser_enabled" => true,
-          "infer_role_from_query" => true,
+          "query_parser_read_write_splitting" => true,
           "automatic_sharding_key" => "data.id",
           "sharding_function" => "pg_bigint_hash",
           "shards" => {

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -34,6 +34,7 @@ module Helpers
           "load_balancing_mode" => lb_mode,
           "primary_reads_enabled" => true,
           "query_parser_enabled" => true,
+          "infer_role_from_query" => true,
           "automatic_sharding_key" => "data.id",
           "sharding_function" => "pg_bigint_hash",
           "shards" => {


### PR DESCRIPTION
Would like to test latency of `QueryPraser::parse` but by default it tries to infer the role. Would like the option to disable that and have query_parser_enabled be a switch to easily turn on and off the query parser to see live latency impact without impacting traffic routing.

Fixes bug where first message isn't parsed and subsequent messages are parsed twice.