### PR TITLE
Add github tag as tag to image

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -34,6 +34,7 @@ jobs:
           tags: |
             type=sha,prefix=,format=long
             type=schedule
+            type=ref,event=tag
             type=ref,event=branch
             type=ref,event=pr
             type=raw,value=latest,enable={{ is_default_branch }}


### PR DESCRIPTION
I saw this issue #528 and suggestion of adding the version tags on github to the prebuild docker images.

This PR adds the pushed tag as a tag to the docker images. It uses the `type=ref,event=tag` of the `tags` input used by the `docker/metadata-action` https://github.com/docker/metadata-action#typeref

With new pushed tags the docker images should get a correct version tag.