### PR TITLE
parse server error messages

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,7 @@ pub enum Error {
     ProtocolSyncError(String),
     BadQuery(String),
     ServerError,
+    ServerMessageParserError(String),
     ServerStartupError(String, ServerIdentifier),
     ServerAuthError(String, ServerIdentifier),
     BadConfig,


### PR DESCRIPTION
This PR adds a parser to the Postgres error message, providing better error messages.

Implemented based in:
  https://www.postgresql.org/docs/12/protocol-error-fields.html