### PR TITLE
Adds option to log which parameter status is changed by the client

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -547,6 +547,9 @@ pub struct Pool {
     #[serde(default = "Pool::default_cleanup_server_connections")]
     pub cleanup_server_connections: bool,
 
+    #[serde(default)] // False
+    pub log_client_parameter_status_changes: bool,
+
     pub plugins: Option<Plugins>,
     pub shards: BTreeMap<String, Shard>,
     pub users: BTreeMap<String, User>,
@@ -696,6 +699,7 @@ impl Default for Pool {
             server_lifetime: None,
             plugins: None,
             cleanup_server_connections: true,
+            log_client_parameter_status_changes: false,
         }
     }
 }
@@ -1156,6 +1160,10 @@ impl Config {
             info!(
                 "[pool: {}] Cleanup server connections: {}",
                 pool_name, pool_config.cleanup_server_connections
+            );
+            info!(
+                "[pool: {}] Log client parameter status changes: {}",
+                pool_name, pool_config.log_client_parameter_status_changes
             );
             info!(
                 "[pool: {}] Plugins: {}",

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -41,6 +41,7 @@ impl MirroredClient {
             Arc::new(RwLock::new(None)),
             None,
             true,
+            false,
         );
 
         Pool::builder()

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -371,6 +371,7 @@ impl ConnectionPool {
                                 None => config.plugins.clone(),
                             },
                             pool_config.cleanup_server_connections,
+                            pool_config.log_client_parameter_status_changes,
                         );
 
                         let connect_timeout = match pool_config.connect_timeout {
@@ -956,6 +957,9 @@ pub struct ServerPool {
 
     /// Should we clean up dirty connections before putting them into the pool?
     cleanup_connections: bool,
+
+    /// Log client parameter status changes
+    log_client_parameter_status_changes: bool,
 }
 
 impl ServerPool {
@@ -967,6 +971,7 @@ impl ServerPool {
         auth_hash: Arc<RwLock<Option<String>>>,
         plugins: Option<Plugins>,
         cleanup_connections: bool,
+        log_client_parameter_status_changes: bool,
     ) -> ServerPool {
         ServerPool {
             address,
@@ -976,6 +981,7 @@ impl ServerPool {
             auth_hash,
             plugins,
             cleanup_connections,
+            log_client_parameter_status_changes,
         }
     }
 }
@@ -1005,6 +1011,7 @@ impl ManageConnection for ServerPool {
             stats.clone(),
             self.auth_hash.clone(),
             self.cleanup_connections,
+            self.log_client_parameter_status_changes,
         )
         .await
         {


### PR DESCRIPTION
This PR helps to debug what kind of parameters are being set by the client outside of the startup. This will only log for SET statements that respond with a ParameterStatus packet
```
set application_name to 'name';
```
will return a parameter status but 
```
set statement_timeout to 10;
```
will not return a parameter status and will not be logged