### PR TITLE
Fixes try_execute_command message parsing bug

### DIFF
--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -141,6 +141,7 @@ impl QueryRouter {
         let mut message_cursor = Cursor::new(message_buffer);
 
         let code = message_cursor.get_u8() as char;
+        let len = message_cursor.get_i32() as usize;
 
         // Check for any sharding regex matches in any queries
         match code as char {
@@ -150,7 +151,6 @@ impl QueryRouter {
                     || self.pool_settings.sharding_key_regex.is_some()
                 {
                     // Check only the first block of bytes configured by the pool settings
-                    let len = message_cursor.get_i32() as usize;
                     let seg = cmp::min(len - 5, self.pool_settings.regex_search_limit);
                     let initial_segment = String::from_utf8_lossy(&message_buffer[0..seg]);
 
@@ -192,7 +192,6 @@ impl QueryRouter {
             return None;
         }
 
-        let _len = message_cursor.get_i32() as usize;
         let query = message_cursor.read_string().unwrap();
 
         let regex_set = match CUSTOM_SQL_REGEX_SET.get() {

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1295,6 +1295,11 @@ mod test {
         // Shard should start out unset
         assert_eq!(qr.active_shard, None);
 
+        // Don't panic when short query eg. ; is sent
+        let q0 = simple_query(";");
+        assert!(qr.try_execute_command(&q0) == None);
+        assert_eq!(qr.active_shard, None);
+
         // Make sure setting it works
         let q1 = simple_query("/* shard_id: 1 */ select 1 from foo;");
         assert!(qr.try_execute_command(&q1) == None);


### PR DESCRIPTION
We were double reading the length of the message, this was masked when we had longer queries where we could read those extra bytes without causing an issue.  A ruby health check change uncovered that when sending something like `;` as a query we were running into panics because the buffer did not have the expected number of bytes.