### PR TITLE
Fix Docker image runs erroring due to glibc incompatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM rust:1 AS builder
+FROM rust:1-slim-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y build-essential
+
 COPY . /app
 WORKDIR /app
 RUN cargo build --release
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat
 COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
 WORKDIR /etc/pgcat


### PR DESCRIPTION
The base Docker image used for building, rust:1, is running a different version of glibc than that of the image used for executing pgcat, debian:bullseye. And apparently Rust requires the that the glibc version used for building be compatible with the one used to execute the binary (https://github.com/rust-lang/rust/issues/57497). 

This PR fixes that and also upgrades the Debian version.