### PR TITLE
Include `thread_id` in the logs

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -8,6 +8,7 @@ pub fn init(args: &Args) {
     let filter = EnvFilter::from_default_env().add_directive(args.log_level.into());
 
     let trace_sub = tracing_subscriber::fmt()
+        .with_thread_ids(true)
         .with_env_filter(filter)
         .with_ansi(!args.no_color);
 


### PR DESCRIPTION
Currently, it's really hard to make sense of logs in presence of multiple workers. This change helps with fixing the issue.