### PR TITLE
Add a cache layer to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM rust:1-slim-bookworm AS builder
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 
 RUN apt-get update && \
     apt-get install -y build-essential
 
-COPY . /app
 WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+FROM rust:1-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y build-essential
 
+COPY . /app
 WORKDIR /app
-
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder 
-COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
-# Build application
-COPY . .
 RUN cargo build --release
 
 FROM debian:bookworm-slim

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+
+RUN apt-get update && \
+    apt-get install -y build-essential
+
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat
+COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
+WORKDIR /etc/pgcat
+ENV RUST_LOG=info
+CMD ["pgcat"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 # Build application
 COPY . .
-RUN cargo build --release
+RUN cargo build
 
 FROM debian:bookworm-slim
 COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat


### PR DESCRIPTION
This PR adds a cache later to Docker using `cargo-chef`. This change has a noticeable improvement in the turnaround time if someone is using Docker in their development cycle.