### PR TITLE
Mark admin clients as disconnected on error

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -155,10 +155,10 @@ pub async fn client_entrypoint(
 
                         if !client.is_admin() {
                             let _ = drain.send(-1).await;
+                        }
 
-                            if result.is_err() {
-                                client.stats.disconnect();
-                            }
+                        if result.is_err() {
+                            client.stats.disconnect();
                         }
 
                         result
@@ -207,10 +207,10 @@ pub async fn client_entrypoint(
 
                                 if !client.is_admin() {
                                     let _ = drain.send(-1).await;
+                                }
 
-                                    if result.is_err() {
-                                        client.stats.disconnect();
-                                    }
+                                if result.is_err() {
+                                    client.stats.disconnect();
                                 }
 
                                 result
@@ -261,10 +261,10 @@ pub async fn client_entrypoint(
 
                     if !client.is_admin() {
                         let _ = drain.send(-1).await;
+                    }
 
-                        if result.is_err() {
-                            client.stats.disconnect();
-                        }
+                    if result.is_err() {
+                        client.stats.disconnect();
                     }
 
                     result
@@ -290,11 +290,12 @@ pub async fn client_entrypoint(
 
                     if !client.is_admin() {
                         let _ = drain.send(-1).await;
-
-                        if result.is_err() {
-                            client.stats.disconnect();
-                        }
                     }
+
+                    if result.is_err() {
+                        client.stats.disconnect();
+                    }
+
                     result
                 }
 
@@ -1811,7 +1812,6 @@ impl<S, T> Drop for Client<S, T> {
 
         // Dirty shutdown
         // TODO: refactor, this is not the best way to handle state management.
-
         if self.connected_to_server && self.last_server_stats.is_some() {
             self.last_server_stats.as_ref().unwrap().idle();
         }


### PR DESCRIPTION
Mark admin clients as disconnected as well, on error. We're leaking admin clients in stats before this.

TODO: We have 4 identical pieces of code handling the same thing copy/pasted. Should refactor into a single function.