### PR TITLE
Improvement of the TLS protocol

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -81,6 +81,16 @@ default: false
 
 Whether to verify server certificate or not.
 
+### trust_os_certificates
+```
+path: general.trust_os_certificates
+default: false
+```
+
+If the `verify_server_certificate` setting is enabled, the database
+server certificate will be verified not only through the built-in root
+certificates, but also through the operating system root certificates.
+
 ### verify_config
 ```
 path: general.verify_config

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -63,7 +63,7 @@ path: general.server_round_robin
 default: false
 ```
 
-Whether to use round robin for server selection or not.
+Whether to use round-robin for server selection or not.
 
 ### server_tls
 ```
@@ -71,15 +71,34 @@ path: general.server_tls
 default: false
 ```
 
-Whether to use TLS for server connections or not.
+Attempt to establish a TLS connection to the DB server.
+
+When enabling this feature, it is also important to configure the `general.verify_server_certificate` setting.
+
+If this is disabled, it is equivalent to `sslmode=disable`.
+
 
 ### verify_server_certificate
 ```
 path: general.verify_server_certificate
 default: false
+accepted values: true / false / "only-ca"
 ```
 
 Whether to verify server certificate or not.
+
+This feature only works when the `general.server_tls` setting is enabled.
+
+`false` - Server certificate validation is not performed at all. If the server
+allows to establish TLS connection, the connection will be established via
+https protocol, if not, it will be established via http. (similar to the
+`sslmode=prefer` mode)
+
+`true` - Connection to the DB server will be made with full server certificate
+verification. (similar to `sslmode=verify-full` mode)
+
+`"only-ca"` - Connection to the DB server will be made with full server
+certificate verification except for the hostname. (similar to `sslmode=verify-ca` mode)
 
 ### trust_os_certificates
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1035,7 @@ dependencies = [
  "rand",
  "regex",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_derive",
@@ -1300,6 +1317,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1386,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ itertools = "0.10"
 clap = { version = "4.3.1", features = ["derive", "env"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter", "std"]}
+rustls-native-certs = "0.6.3"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -77,6 +77,11 @@ server_tls = false
 # Verify server certificate is completely authentic.
 verify_server_certificate = false
 
+# If the `verify_server_certificate` setting is enabled, the database
+# server certificate will be verified not only through the built-in root
+# certificates, but also through the operating system root certificates.
+trust_os_certificates = false
+
 # User name to access the virtual administrative database (pgbouncer or pgcat)
 # Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DATABASES`, etc..
 admin_username = "admin_user"

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,49 +281,6 @@ impl Default for CertificateVerificationVariant {
     }
 }
 
-/*
-impl CustomSerialize for CertificateVerificationVariant {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-    {
-        match self {
-            Self::Bool(val) => serializer.serialize_bool(*val),
-            Self::String(val) => serializer.serialize_str(val.as_str()),
-        }
-    }
-}
-
-impl<'de> CustomDeserialize<'de> for CertificateVerificationVariant {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-    {
-        deserializer.deserialize_bool()
-
-        /*
-        match String::deserialize(deserializer) {
-            Ok(v) => match v.as_str() {
-                "only-ca" => {},
-                _ => return Err(D::Error::unknown_variant(v.as_str(), []))
-            },
-            Err(err) => {}
-        }
-
-
-        //error!("Invalid shard {:?}", shard_number);
-        //return Err(Error::BadConfig);
-
-        Ok(match variant.to_lowercase().as_str() {
-            "false" => VerifyServerCertificate::Prefer,
-            "true" => VerifyServerCertificate::VerifyCa,
-            "only-ca" => VerifyServerCertificate::VerifyFull,
-            _ => {}
-        })*/
-    }
-}
-*/
-
 /// General configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct General {

--- a/src/config.rs
+++ b/src/config.rs
@@ -331,6 +331,9 @@ pub struct General {
     #[serde(default)] // false
     pub verify_server_certificate: bool,
 
+    #[serde(default)]
+    pub trust_os_certificates: bool,
+
     pub admin_username: String,
     pub admin_password: String,
 
@@ -462,6 +465,7 @@ impl Default for General {
             tls_private_key: None,
             server_tls: false,
             verify_server_certificate: false,
+            trust_os_certificates: false,
             admin_username: String::from("admin"),
             admin_password: String::from("admin"),
             auth_query: None,

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -3,7 +3,7 @@
 use rustls_pemfile::{certs, read_one, Item};
 use std::iter;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::SystemTime;
 use tokio_rustls::rustls::{
     self,
@@ -14,6 +14,12 @@ use tokio_rustls::TlsAcceptor;
 
 use crate::config::get_config;
 use crate::errors::Error;
+
+// OS Root certificates
+static OS_ROOT_CERTIFICATES: OnceLock<Result<Vec<rustls_native_certs::Certificate>, std::io::Error>> = OnceLock::new();
+pub fn get_os_root_certificates() -> &'static Result<Vec<rustls_native_certs::Certificate>, std::io::Error> {
+    OS_ROOT_CERTIFICATES.get_or_init(|| rustls_native_certs::load_native_certs())
+}
 
 // TLS
 pub fn load_certs(path: &Path) -> std::io::Result<Vec<Certificate>> {


### PR DESCRIPTION
## Reason for this PR
Issue #598

## Description of Changes
1. New setting in the configuration file is `general.trust_os_certificates`. Which means whether the developer can trust not only the built-in certificates in PGCat, but also the OS root certificates
2. Optional `only-ca` mode to configure `general.verify_server_certificate`. It is equivalent to the `sslmode=verify-ca` mode

## License Acceptance
By submitting this pull request, I confirm that my contribution is made under
the terms of the [PGCat license](https://github.com/postgresml/pgcat/blob/main/LICENSE).
