### PR TITLE
Add psql to the container image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ WORKDIR /app
 RUN cargo build --release
 
 FROM debian:bookworm-slim
+RUN apt-get update && apt-get install  -o Dpkg::Options::=--force-confdef -yq --no-install-recommends \
+    postgresql-client \
+    # Clean up layer
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && truncate -s 0 /var/log/*log
 COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat
 COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
 WORKDIR /etc/pgcat


### PR DESCRIPTION
I'd like to propose that we add `psql` to the container image.

We are currently using it to implement container health checks this way:
  `PGPASSWORD="<some-password>" psql -U pgcat -p 6432 -h 127.0.0.1 -tA -c "show version;" -d pgcat >/dev/null`

and would be keen to use the `ghcr.io/postgresml/pgcat` image directly without having to rebuild our own.

Unless there is a better way to detect pgcat getting unhealthy?