### PR TITLE
Avoid generating warning on unsupported statements

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -10,7 +10,7 @@ set -o xtrace
 # for inspection.
 function start_pgcat() {
     kill -s SIGINT $(pgrep pgcat) || true
-    RUST_LOG=${1} ./target/debug/pgcat .circleci/pgcat.toml &
+    ./target/debug/pgcat .circleci/pgcat.toml --log-level ${1} &
     sleep 1
 }
 
@@ -28,6 +28,9 @@ PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard2 -i
 # Start Toxiproxy
 LOG_LEVEL=error toxiproxy-server &
 sleep 1
+
+# Remove toxiproxy if it exists.
+toxiproxy-cli delete postgres_replica || true
 
 # Create a database at port 5433, forward it to Postgres
 toxiproxy-cli create -l 127.0.0.1:5433 -u 127.0.0.1:5432 postgres_replica

--- a/src/client.rs
+++ b/src/client.rs
@@ -890,7 +890,7 @@ where
 
                 'Q' => {
                     if query_router.query_parser_enabled() {
-                        match query_router.parse(&message) {
+                        initial_parsed_ast = Some(match query_router.parse(&message) {
                             Ok(ast) => {
                                 let plugin_result = query_router.execute_plugins(&ast).await;
 
@@ -910,15 +910,20 @@ where
 
                                 let _ = query_router.infer(&ast);
 
-                                initial_parsed_ast = Some(ast);
+                                ast
                             }
                             Err(error) => {
-                                warn!(
-                                    "Query parsing error: {} (client: {})",
-                                    error, client_identifier
-                                );
+                                if error != Error::UnsupportedStatement {
+                                    warn!(
+                                        "Query parsing error: {} (client: {})",
+                                        error, client_identifier
+                                    );
+                                }
+                                // Returning an empty vector shows the failed parse attempt and
+                                // avoids another round of parse attempt below.
+                                vec![]
                             }
-                        }
+                        })
                     }
                 }
 
@@ -940,10 +945,12 @@ where
                                 let _ = query_router.infer(&ast);
                             }
                             Err(error) => {
-                                warn!(
-                                    "Query parsing error: {} (client: {})",
-                                    error, client_identifier
-                                );
+                                if error != Error::UnsupportedStatement {
+                                    warn!(
+                                        "Query parsing error: {} (client: {})",
+                                        error, client_identifier
+                                    );
+                                }
                             }
                         };
                     }
@@ -1273,14 +1280,25 @@ where
                         if query_router.query_parser_enabled() {
                             // We don't want to parse again if we already parsed it as the initial message
                             let ast = match initial_parsed_ast {
-                                Some(_) => Some(initial_parsed_ast.take().unwrap()),
+                                Some(_) => {
+                                    let parsed_ast = initial_parsed_ast.take().unwrap();
+                                    // if 'parsed_ast' is empty, it means that there was a failed
+                                    // attempt to parse the query as a custom command, earlier above.
+                                    if parsed_ast.is_empty() {
+                                        None
+                                    } else {
+                                        Some(parsed_ast)
+                                    }
+                                }
                                 None => match query_router.parse(&message) {
                                     Ok(ast) => Some(ast),
                                     Err(error) => {
-                                        warn!(
-                                            "Query parsing error: {} (client: {})",
-                                            error, client_identifier
-                                        );
+                                        if error != Error::UnsupportedStatement {
+                                            warn!(
+                                                "Query parsing error: {} (client: {})",
+                                                error, client_identifier
+                                            );
+                                        }
                                         None
                                     }
                                 },

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -338,6 +338,8 @@ impl QueryRouter {
         Some((command, value))
     }
 
+    const UNSUPPORTED_STATEMENTS_FOR_PARSING: [&'static str; 3] = ["COPY", "TRUNCATE", "VACUUM"];
+
     pub fn parse(&self, message: &BytesMut) -> Result<Vec<Statement>, Error> {
         let mut message_cursor = Cursor::new(message);
 
@@ -380,8 +382,22 @@ impl QueryRouter {
         match Parser::parse_sql(&PostgreSqlDialect {}, &query) {
             Ok(ast) => Ok(ast),
             Err(err) => {
-                debug!("{}: {}", err, query);
-                Err(Error::QueryRouterParserError(err.to_string()))
+                let qry_upper = query.to_ascii_uppercase();
+
+                // Check for unsupported statements to avoid producing a warning.
+                // Note 1: this is not a complete list of unsupported statements.
+                // Note 2: we do not check for unsupported statements before going through the
+                //         parser, as the plugin system might be able to handle them, once sqlparser
+                //         is able to correctly parse these (rather valid) queries.
+                if Self::UNSUPPORTED_STATEMENTS_FOR_PARSING
+                    .iter()
+                    .any(|s| qry_upper.starts_with(s))
+                {
+                    Err(Error::UnsupportedStatement)
+                } else {
+                    debug!("{}: {}", err, query);
+                    Err(Error::QueryRouterParserError(err.to_string()))
+                }
             }
         }
     }
@@ -1864,6 +1880,7 @@ mod test {
 
         let query = simple_query("SELECT * FROM pg_database");
         let ast = qr.parse(&query).unwrap();
+        println!(">>> {:?}", ast);
 
         let res = qr.execute_plugins(&ast).await;
 


### PR DESCRIPTION
Currently, not all acceptable PostgreSQL queries are parsed correctly by `sqlparser`. As a long-term direction, I think we should invest in making it possible. I created issue #620 to track that.

However, for now, we can avoid producing warning messages on queries that we know will fail. This removes the warning message from the test outputs, as well.

In addition, this PR applies some improvements to the test script.