### PR TITLE
Add connet_timeout and idle_timeout to the user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pgcat"
-version = "1.1.2-dev1"
+version = "1.1.2-dev2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "1.1.2-dev1"
+version = "1.1.2-dev2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -302,6 +302,7 @@ password = "other_user"
 pool_size = 21
 statement_timeout = 15000
 connect_timeout = 1000
+idle_timeout = 1000
 
 # Shard configs are structured as pool.<pool_name>.shards.<shard_id>
 # Each shard config contains a list of servers that make up the shard

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -301,6 +301,7 @@ username = "other_user"
 password = "other_user"
 pool_size = 21
 statement_timeout = 15000
+connect_timeout = 1000
 
 # Shard configs are structured as pool.<pool_name>.shards.<shard_id>
 # Each shard config contains a list of servers that make up the shard

--- a/src/auth_passthrough.rs
+++ b/src/auth_passthrough.rs
@@ -80,6 +80,7 @@ impl AuthPassthrough {
             server_lifetime: None,
             min_pool_size: None,
             connect_timeout: None,
+            idle_timeout: None,
         };
 
         let user = &address.username;

--- a/src/auth_passthrough.rs
+++ b/src/auth_passthrough.rs
@@ -79,6 +79,7 @@ impl AuthPassthrough {
             pool_mode: None,
             server_lifetime: None,
             min_pool_size: None,
+            connect_timeout: None,
         };
 
         let user = &address.username;

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,6 +216,7 @@ pub struct User {
     pub server_lifetime: Option<u64>,
     #[serde(default)] // 0
     pub statement_timeout: u64,
+    pub connect_timeout: Option<u64>,
 }
 
 impl Default for User {
@@ -230,6 +231,7 @@ impl Default for User {
             statement_timeout: 0,
             pool_mode: None,
             server_lifetime: None,
+            connect_timeout: None,
         }
     }
 }
@@ -1305,6 +1307,15 @@ impl Config {
                     match user.1.server_lifetime {
                         Some(server_lifetime) => format!("{}ms", server_lifetime),
                         None => "default".to_string(),
+                    }
+                );
+                info!(
+                    "[pool: {}][user: {}] Connection timeout: {}",
+                    pool_name,
+                    user.1.username,
+                    match user.1.connect_timeout {
+                        Some(connect_timeout) => format!("{}ms", connect_timeout),
+                        None => "not set".to_string(),
                     }
                 );
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ pub struct User {
     #[serde(default)] // 0
     pub statement_timeout: u64,
     pub connect_timeout: Option<u64>,
+    pub idle_timeout: Option<u64>,
 }
 
 impl Default for User {
@@ -232,6 +233,7 @@ impl Default for User {
             pool_mode: None,
             server_lifetime: None,
             connect_timeout: None,
+            idle_timeout: None,
         }
     }
 }
@@ -1315,6 +1317,15 @@ impl Config {
                     user.1.username,
                     match user.1.connect_timeout {
                         Some(connect_timeout) => format!("{}ms", connect_timeout),
+                        None => "not set".to_string(),
+                    }
+                );
+                info!(
+                    "[pool: {}][user: {}] Idle timeout: {}",
+                    pool_name,
+                    user.1.username,
+                    match user.1.idle_timeout {
+                        Some(idle_timeout) => format!("{}ms", idle_timeout),
                         None => "not set".to_string(),
                     }
                 );

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -444,9 +444,12 @@ impl ConnectionPool {
                             },
                         };
 
-                        let idle_timeout = match pool_config.idle_timeout {
+                        let idle_timeout = match user.idle_timeout {
                             Some(idle_timeout) => idle_timeout,
-                            None => config.general.idle_timeout,
+                            None => match pool_config.idle_timeout {
+                                Some(idle_timeout) => idle_timeout,
+                                None => config.general.idle_timeout,
+                            },
                         };
 
                         let server_lifetime = match user.server_lifetime {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -436,10 +436,15 @@ impl ConnectionPool {
                             pool_config.prepared_statements_cache_size,
                         );
 
-                        let connect_timeout = match pool_config.connect_timeout {
+                        let connect_timeout = match user.connect_timeout {
                             Some(connect_timeout) => connect_timeout,
-                            None => config.general.connect_timeout,
+                            None => match pool_config.connect_timeout {
+                                Some(connect_timeout) => connect_timeout,
+                                None => config.general.connect_timeout,
+                            },
                         };
+
+                        println!("connect timeout: {}", connect_timeout);
 
                         let idle_timeout = match pool_config.idle_timeout {
                             Some(idle_timeout) => idle_timeout,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -444,8 +444,6 @@ impl ConnectionPool {
                             },
                         };
 
-                        println!("connect timeout: {}", connect_timeout);
-
                         let idle_timeout = match pool_config.idle_timeout {
                             Some(idle_timeout) => idle_timeout,
                             None => config.general.idle_timeout,


### PR DESCRIPTION
Allow the user to configure `idle_timeout` and `connect_timeout` for the pool.