### PR TITLE
Expose clients maxwait time in SHOW CLIENTS response via admin

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -690,7 +690,7 @@ where
         ("query_count", DataType::Numeric),
         ("error_count", DataType::Numeric),
         ("age_seconds", DataType::Numeric),
-        ("maxwait_seconds", DataType::Numeric),
+        ("maxwait", DataType::Numeric),
         ("maxwait_us", DataType::Numeric),
     ];
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -690,6 +690,8 @@ where
         ("query_count", DataType::Numeric),
         ("error_count", DataType::Numeric),
         ("age_seconds", DataType::Numeric),
+        ("maxwait_seconds", DataType::Numeric),
+        ("maxwait_us", DataType::Numeric),
     ];
 
     let new_map = get_client_stats();
@@ -697,6 +699,7 @@ where
     res.put(row_description(&columns));
 
     for (_, client) in new_map {
+        let max_wait = client.max_wait_time.load(Ordering::Relaxed);
         let row = vec![
             format!("{:#010X}", client.client_id()),
             client.pool_name(),
@@ -710,6 +713,8 @@ where
                 .duration_since(client.connect_time())
                 .as_secs()
                 .to_string(),
+            (max_wait / 1_000_000).to_string(),
+            (max_wait % 1_000_000).to_string(),
         ];
 
         res.put(data_row(&row));

--- a/tests/ruby/stats_spec.rb
+++ b/tests/ruby/stats_spec.rb
@@ -346,8 +346,8 @@ describe "Stats" do
 
         normal_client_results = results.reject { |r| r["database"] == "pgcat" }
 
-        non_waiting_clients = normal_client_results.select { |c| c["maxwait_seconds"] == "0" }
-        waiting_clients = normal_client_results.select { |c| c["maxwait_seconds"].to_i > 0 }
+        non_waiting_clients = normal_client_results.select { |c| c["maxwait"] == "0" }
+        waiting_clients = normal_client_results.select { |c| c["maxwait"].to_i > 0 }
 
         expect(non_waiting_clients.count).to eq(2)
         non_waiting_clients.each do |client|

--- a/tests/ruby/stats_spec.rb
+++ b/tests/ruby/stats_spec.rb
@@ -329,6 +329,40 @@ describe "Stats" do
       admin_conn.close
       connections.map(&:close)
     end
+
+    context "when client has waited for a server" do
+      let(:processes) { Helpers::Pgcat.single_instance_setup("sharded_db", 2) }
+
+      it "shows correct maxwait" do
+        threads = []
+        connections = Array.new(3) { |i| PG::connect("#{pgcat_conn_str}?application_name=app#{i}") }
+        connections.each do |c|
+          threads << Thread.new { c.async_exec("SELECT pg_sleep(1.5)") rescue nil }
+        end
+
+        sleep(2.5) # Allow time for stats to update
+        admin_conn = PG::connect(processes.pgcat.admin_connection_string)
+        results = admin_conn.async_exec("SHOW CLIENTS")
+
+        normal_client_results = results.reject { |r| r["database"] == "pgcat" }
+
+        non_waiting_clients = normal_client_results.select { |c| c["maxwait_seconds"] == "0" }
+        waiting_clients = normal_client_results.select { |c| c["maxwait_seconds"].to_i > 0 }
+
+        expect(non_waiting_clients.count).to eq(2)
+        non_waiting_clients.each do |client|
+          expect(client["maxwait_us"].to_i).to be_between(0, 50_000)
+        end
+
+        expect(waiting_clients.count).to eq(1)
+        waiting_clients.each do |client|
+          expect(client["maxwait_us"].to_i).to be_within(200_000).of(500_000)
+        end
+
+        admin_conn.close
+        connections.map(&:close)
+      end
+    end
   end
 
 


### PR DESCRIPTION
Displays the maxwait via maxwait_seconds and maxwait_us columns for each client. This can be used to track down the wait time per client in a case where the overall pool stats shows increased waiting time.

The maxwait_us value is configured as a remainder of the total maxwait alongside the maxwait_seconds to match how we display it for the overall pool wait time.