### PR TITLE
Dont cache prepared statement with errors

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -119,6 +119,13 @@ popd
 
 start_pgcat "info"
 
+#
+# Rust tests
+#
+cd tests/rust
+cargo run
+cd ../../
+
 # Admin tests
 export PGPASSWORD=admin_pass
 psql -U admin_user -e -h 127.0.0.1 -p 6432 -d pgbouncer -c 'SHOW STATS' > /dev/null

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pgcat"
-version = "1.1.2-dev2"
+version = "1.1.2-dev4"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "1.1.2-dev2"
+version = "1.1.2-dev4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/client.rs
+++ b/src/client.rs
@@ -959,7 +959,6 @@ where
                         query_router.infer_shard_from_bind(&message);
                     }
 
-                    debug!("Buffering Bind");
                     self.buffer_bind(message).await?;
 
                     continue;
@@ -1366,10 +1365,8 @@ where
                                     }
                                 }
                                 ExtendedProtocolData::Bind { data, metadata } => {
-                                    debug!("Have bind in extended buffer");
                                     // This is using a prepared statement
                                     if let Some(client_given_name) = metadata {
-                                        debug!("Ensuring prepared statement is on server bind");
                                         self.ensure_prepared_statement_is_on_server(
                                             client_given_name,
                                             &pool,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1383,10 +1383,8 @@ where
                                     self.buffer.put(&data[..]);
                                 }
                                 ExtendedProtocolData::Describe { data, metadata } => {
-                                    debug!("Have describe in extended buffer");
                                     // This is using a prepared statement
                                     if let Some(client_given_name) = metadata {
-                                        debug!("Ensuring prepared statement is on server describe");
                                         self.ensure_prepared_statement_is_on_server(
                                             client_given_name,
                                             &pool,
@@ -1394,18 +1392,14 @@ where
                                             &address,
                                         )
                                         .await?;
-                                    } else {
-                                        debug!("Anonymous describe");
                                     }
 
                                     self.buffer.put(&data[..]);
                                 }
                                 ExtendedProtocolData::Execute { data } => {
-                                    debug!("Have execute in  extended buffer");
                                     self.buffer.put(&data[..])
                                 }
                                 ExtendedProtocolData::Close { data, close } => {
-                                    debug!("Have close in  extended buffer");
                                     // We don't send the close message to the server if prepared statements are enabled
                                     // and it's a close with a prepared statement name provided
                                     if self.prepared_statements_enabled
@@ -1455,7 +1449,6 @@ where
                         }
 
                         if should_send_to_server {
-                            debug!("Should send to server");
                             self.send_and_receive_loop(
                                 code,
                                 None,
@@ -1918,17 +1911,9 @@ where
         debug!("Sending {} to server", code);
 
         let message = match message {
-            Some(message) => {
-                debug!("Lonely message");
-                message
-            }
-            None => {
-                debug!("Buffered message");
-                &self.buffer
-            }
+            Some(message) => message,
+            None => &self.buffer,
         };
-
-        debug!("Message contents: {:?}", message);
 
         self.send_server_message(server, message, address, pool)
             .await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1189,9 +1189,9 @@ where
                                 };
                             }
                         }
+
                         debug!("Sending query to server");
 
-                        debug!("The other kind");
                         self.send_and_receive_loop(
                             code,
                             Some(&message),
@@ -1245,7 +1245,6 @@ where
                     // Bind
                     // The placeholder's replacements are here, e.g. 'user@email.com' and 'true'
                     'B' => {
-                        debug!("Buffering bind transaction");
                         self.buffer_bind(message).await?;
                     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,7 @@ pub enum Error {
     QueryRouterParserError(String),
     QueryRouterError(String),
     InvalidShardId(usize),
+    PreparedStatementError,
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -16,7 +16,14 @@ async fn test_prepared_statements() {
         let pool = pool.clone();
         let handle = tokio::task::spawn(async move {
             for _ in 0..1000 {
-                sqlx::query("SELECT 1").fetch_all(&pool).await.unwrap();
+                match sqlx::query("SELECT one").fetch_all(&pool).await {
+                    Ok(_) => (),
+                    Err(err) => {
+                        if err.to_string().contains("prepared statement") {
+                            panic!("prepared statement error: {}", err);
+                        }
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
If a prepared statement has an error, don't cache it in the pooler. Postgres certainly won't.