### PR TITLE
Require a reason when marking a server bad

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1437,7 +1437,7 @@ where
                             .await
                             {
                                 // We might be in some kind of error/in between protocol state
-                                server.mark_bad();
+                                server.mark_bad(err.to_string().as_str());
                                 return Err(err);
                             }
 
@@ -1504,7 +1504,7 @@ where
                         match write_all_flush(&mut self.write, &response).await {
                             Ok(_) => (),
                             Err(err) => {
-                                server.mark_bad();
+                                server.mark_bad(err.to_string().as_str());
                                 return Err(err);
                             }
                         };
@@ -1926,7 +1926,7 @@ where
                 Ok(_) => (),
                 Err(err) => {
                     // We might be in some kind of error/in between protocol state, better to just kill this server
-                    server.mark_bad();
+                    server.mark_bad(err.to_string().as_str());
                     return Err(err);
                 }
             };
@@ -1993,11 +1993,13 @@ where
                 }
             },
             Err(_) => {
-                error!(
-                    "Statement timeout while talking to {:?} with user {}",
-                    address, pool.settings.user.username
+                server.mark_bad(
+                    format!(
+                        "Statement timeout while talking to {:?} with user {}",
+                        address, pool.settings.user.username
+                    )
+                    .as_str(),
                 );
-                server.mark_bad();
                 pool.ban(address, BanReason::StatementTimeout, Some(client_stats));
                 error_response_terminal(&mut self.write, "pool statement timeout").await?;
                 Err(Error::StatementTimeout)

--- a/src/mirrors.rs
+++ b/src/mirrors.rs
@@ -85,8 +85,9 @@ impl MirroredClient {
                         match recv_result {
                             Ok(message) => trace!("Received from mirror: {} {:?}", String::from_utf8_lossy(&message[..]), address.clone()),
                             Err(err) => {
-                                server.mark_bad();
-                                error!("Failed to receive from mirror {:?} {:?}", err, address.clone());
+                                server.mark_bad(
+                                    format!("Failed to send to mirror, Discarding message {:?}, {:?}", err, address.clone()).as_str()
+                                );
                             }
                         }
                     }
@@ -98,8 +99,9 @@ impl MirroredClient {
                                 match server.send(&BytesMut::from(&bytes[..])).await {
                                     Ok(_) => trace!("Sent to mirror: {} {:?}", String::from_utf8_lossy(&bytes[..]), address.clone()),
                                     Err(err) => {
-                                        server.mark_bad();
-                                        error!("Failed to send to mirror, Discarding message {:?}, {:?}", err, address.clone())
+                                        server.mark_bad(
+                                            format!("Failed to receive from mirror {:?} {:?}", err, address.clone()).as_str()
+                                        );
                                     }
                                 }
                             }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -871,7 +871,7 @@ impl ConnectionPool {
         }
 
         // Don't leave a bad connection in the pool.
-        server.mark_bad();
+        server.mark_bad("failed health check");
 
         self.ban(address, BanReason::FailedHealthCheck, Some(client_info));
         false

--- a/src/server.rs
+++ b/src/server.rs
@@ -1279,8 +1279,8 @@ impl Server {
     }
 
     /// Indicate that this server connection cannot be re-used and must be discarded.
-    pub fn mark_bad(&mut self) {
-        error!("Server {:?} marked bad", self.address);
+    pub fn mark_bad(&mut self, reason: &str) {
+        error!("Server {:?} marked bad, reason: {}", self.address, reason);
         self.bad = true;
     }
 


### PR DESCRIPTION
When calling mark_bad require a reason so it can be logged rather than
the generic message. Relates to #648
