### PR TITLE
Use rust:bullseye as base image

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-bullseye
+FROM rust:bullseye
 
 # Dependencies
 COPY --from=sclevine/yj /bin/yj /bin/yj


### PR DESCRIPTION
With the original `rust:1.70-bullseye` image, the container cannot be built:

```
17.06   Installing /usr/local/cargo/bin/rustfilt
17.06    Installed package `rustfilt v0.2.1` (executable `rustfilt`)
17.06 error: failed to compile `cargo-binutils v0.3.6`, intermediate artifacts can be found at `/tmp/cargo-installrc6mPb`
17.06
17.06 Caused by:
17.06   package `cargo-platform v0.1.8` cannot be built because it requires rustc 1.73 or newer, while the currently active rustc version is 1.70.0
17.06   Try re-running cargo install with `--locked`
17.06      Summary Successfully installed rustfilt! Failed to install cargo-binutils (see error(s) above).
17.06 error: some crates failed to install
```

`rust:bullseye` is the same base image used on `tests/docker/Dockerfile`

Let me know if a different base image should be used, I can update my PR.