### PR TITLE
Force client TLS

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -65,6 +65,9 @@ tcp_keepalives_interval = 5
 # Path to TLS private key file to use for TLS connections
 # tls_private_key = ".circleci/server.key"
 
+# Disconnect clients not using TLS
+force_client_tls = false
+
 # Enable/disable server TLS
 server_tls = false
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -241,42 +241,49 @@ pub async fn client_entrypoint(
         Ok((ClientConnectionType::Startup, bytes)) => {
             let (read, write) = split(stream);
 
-            // Continue with regular startup.
-            match Client::startup(
-                read,
-                write,
-                addr,
-                bytes,
-                client_server_map,
-                shutdown,
-                admin_only,
-            )
-            .await
-            {
-                Ok(mut client) => {
-                    if log_client_connections {
-                        info!("Client {:?} connected (plain)", addr);
-                    } else {
-                        debug!("Client {:?} connected (plain)", addr);
+            if get_config().general.force_client_tls {
+                info!("Rejecting plain connection from client {:?}", addr);
+                Err(Error::ClientError(String::from(
+                    "Rejecting attempt of plain connection",
+                )))
+            } else {
+                // Continue with regular startup.
+                match Client::startup(
+                    read,
+                    write,
+                    addr,
+                    bytes,
+                    client_server_map,
+                    shutdown,
+                    admin_only,
+                )
+                .await
+                {
+                    Ok(mut client) => {
+                        if log_client_connections {
+                            info!("Client {:?} connected (plain)", addr);
+                        } else {
+                            debug!("Client {:?} connected (plain)", addr);
+                        }
+
+                        if !client.is_admin() {
+                            let _ = drain.send(1).await;
+                        }
+
+                        let result = client.handle().await;
+
+                        if !client.is_admin() {
+                            let _ = drain.send(-1).await;
+                        }
+
+                        if result.is_err() {
+                            client.stats.disconnect();
+                        }
+
+                        result
                     }
-
-                    if !client.is_admin() {
-                        let _ = drain.send(1).await;
-                    }
-
-                    let result = client.handle().await;
-
-                    if !client.is_admin() {
-                        let _ = drain.send(-1).await;
-                    }
-
-                    if result.is_err() {
-                        client.stats.disconnect();
-                    }
-
-                    result
+                    Err(err) => Err(err),
                 }
-                Err(err) => Err(err),
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -341,6 +341,9 @@ pub struct General {
     pub auth_query: Option<String>,
     pub auth_query_user: Option<String>,
     pub auth_query_password: Option<String>,
+
+    // Force TLS from clients
+    pub force_client_tls: bool,
 }
 
 impl General {
@@ -422,6 +425,10 @@ impl General {
     pub fn default_server_round_robin() -> bool {
         true
     }
+
+    pub fn default_force_client_tls() -> bool {
+        true
+    }
 }
 
 impl Default for General {
@@ -460,6 +467,7 @@ impl Default for General {
             auth_query: None,
             auth_query_user: None,
             auth_query_password: None,
+            force_client_tls: Self::default_force_client_tls(),
         }
     }
 }


### PR DESCRIPTION
In an attempt to force clients to use TLS, we find a simple way achieve this goal, and want to share this small PR.

It's the first time that I dig into Postgres wire protocol, so I'm not sure if this is the best way to do this. I'd be glad to receive feedback or guidance about how to improve the PR.

I couldn't manage to run `circleci` locally, however, `cargo test` pass.
