### PR TITLE
Report checkout error when all servers are down

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -813,7 +813,7 @@ impl ConnectionPool {
             }
         }
 
-        client_stats.checkout_success();
+        client_stats.checkout_error();
 
         Err(Error::AllServersDown)
     }


### PR DESCRIPTION
We shouldn't report `checkout_success` when we are going to return `Error`.