### PR TITLE
Implement trust (no password) authentication

### DIFF
--- a/pgcat.minimal.toml
+++ b/pgcat.minimal.toml
@@ -11,6 +11,7 @@ admin_password = "pgcat"
 [pools.pgml.users.0]
 username = "postgres"
 password = "postgres"
+auth_type = "md5"
 pool_size = 10
 min_pool_size = 1
 pool_mode = "transaction"

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -274,6 +274,8 @@ result = [
 # if `server_username` is not set.
 username = "sharding_user"
 
+auth_type = "md5"
+
 # PostgreSQL password used to authenticate the user and connect to the server
 # if `server_password` is not set.
 password = "sharding_user"
@@ -299,6 +301,7 @@ statement_timeout = 0
 [pools.sharded_db.users.1]
 username = "other_user"
 password = "other_user"
+auth_type = "md5"
 pool_size = 21
 statement_timeout = 15000
 connect_timeout = 1000
@@ -337,6 +340,7 @@ sharding_function = "pg_bigint_hash"
 [pools.simple_db.users.0]
 username = "simple_user"
 password = "simple_user"
+auth_type = "md5"
 pool_size = 5
 min_pool_size = 3
 server_lifetime = 60000

--- a/src/auth_passthrough.rs
+++ b/src/auth_passthrough.rs
@@ -71,6 +71,7 @@ impl AuthPassthrough {
     pub async fn fetch_hash(&self, address: &crate::config::Address) -> Result<String, Error> {
         let auth_user = crate::config::User {
             username: self.user.clone(),
+            auth_type: "".to_string(),
             password: Some(self.password.clone()),
             server_username: None,
             server_password: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -481,54 +481,57 @@ where
         let process_id: i32 = rand::random();
         let secret_key: i32 = rand::random();
 
-        // Perform MD5 authentication.
-        // TODO: Add SASL support.
-        let salt = md5_challenge(&mut write).await?;
-
-        let code = match read.read_u8().await {
-            Ok(p) => p,
-            Err(_) => {
-                return Err(Error::ClientSocketError(
-                    "password code".into(),
-                    client_identifier,
-                ))
-            }
-        };
-
-        // PasswordMessage
-        if code as char != 'p' {
-            return Err(Error::ProtocolSyncError(format!(
-                "Expected p, got {}",
-                code as char
-            )));
-        }
-
-        let len = match read.read_i32().await {
-            Ok(len) => len,
-            Err(_) => {
-                return Err(Error::ClientSocketError(
-                    "password message length".into(),
-                    client_identifier,
-                ))
-            }
-        };
-
-        let mut password_response = vec![0u8; (len - 4) as usize];
-
-        match read.read_exact(&mut password_response).await {
-            Ok(_) => (),
-            Err(_) => {
-                return Err(Error::ClientSocketError(
-                    "password message".into(),
-                    client_identifier,
-                ))
-            }
-        };
-
         let mut prepared_statements_enabled = false;
 
         // Authenticate admin user.
         let (transaction_mode, mut server_parameters) = if admin {
+
+
+            // Perform MD5 authentication.
+            // TODO: Add SASL support.
+            let salt = md5_challenge(&mut write).await?;
+
+            let code = match read.read_u8().await {
+                Ok(p) => p,
+                Err(_) => {
+                    return Err(Error::ClientSocketError(
+                        "password code".into(),
+                        client_identifier,
+                    ))
+                }
+            };
+
+            // PasswordMessage
+            if code as char != 'p' {
+                return Err(Error::ProtocolSyncError(format!(
+                    "Expected p, got {}",
+                    code as char
+                )));
+            }
+
+            let len = match read.read_i32().await {
+                Ok(len) => len,
+                Err(_) => {
+                    return Err(Error::ClientSocketError(
+                        "password message length".into(),
+                        client_identifier,
+                    ))
+                }
+            };
+
+            let mut password_response = vec![0u8; (len - 4) as usize];
+
+            match read.read_exact(&mut password_response).await {
+                Ok(_) => (),
+                Err(_) => {
+                    return Err(Error::ClientSocketError(
+                        "password message".into(),
+                        client_identifier,
+                    ))
+                }
+            };
+
+
             let config = get_config();
 
             // Compare server and client hashes.
@@ -573,89 +576,136 @@ where
             // Obtain the hash to compare, we give preference to that written in cleartext in config
             // if there is nothing set in cleartext and auth passthrough (auth_query) is configured, we use the hash obtained
             // when the pool was created. If there is no hash there, we try to fetch it one more time.
-            let password_hash = if let Some(password) = &pool.settings.user.password {
-                Some(md5_hash_password(username, password, &salt))
-            } else {
-                if !get_config().is_auth_query_configured() {
-                    wrong_password(&mut write, username).await?;
-                    return Err(Error::ClientAuthImpossible(username.into()));
+            if let "md5" = pool.settings.user.auth_type.as_str() {
+                // Perform MD5 authentication.
+                // TODO: Add SASL support.
+                let salt = md5_challenge(&mut write).await?;
+
+                let code = match read.read_u8().await {
+                    Ok(p) => p,
+                    Err(_) => {
+                        return Err(Error::ClientSocketError(
+                            "password code".into(),
+                            client_identifier,
+                        ))
+                    }
+                };
+
+                // PasswordMessage
+                if code as char != 'p' {
+                    return Err(Error::ProtocolSyncError(format!(
+                        "Expected p, got {}",
+                        code as char
+                    )));
                 }
 
-                let mut hash = (*pool.auth_hash.read()).clone();
+                let len = match read.read_i32().await {
+                    Ok(len) => len,
+                    Err(_) => {
+                        return Err(Error::ClientSocketError(
+                            "password message length".into(),
+                            client_identifier,
+                        ))
+                    }
+                };
 
-                if hash.is_none() {
-                    warn!(
-                        "Query auth configured \
-                          but no hash password found \
-                          for pool {}. Will try to refetch it.",
-                        pool_name
-                    );
+                let mut password_response = vec![0u8; (len - 4) as usize];
 
-                    match refetch_auth_hash(&pool).await {
-                        Ok(fetched_hash) => {
-                            warn!("Password for {}, obtained. Updating.", client_identifier);
+                match read.read_exact(&mut password_response).await {
+                    Ok(_) => (),
+                    Err(_) => {
+                        return Err(Error::ClientSocketError(
+                            "password message".into(),
+                            client_identifier,
+                        ))
+                    }
+                };
 
-                            {
-                                let mut pool_auth_hash = pool.auth_hash.write();
-                                *pool_auth_hash = Some(fetched_hash.clone());
+                let password_hash = if let Some(password) = &pool.settings.user.password {
+
+                    Some(md5_hash_password(username, password, &salt))
+                } else {
+                    if !get_config().is_auth_query_configured() {
+                        wrong_password(&mut write, username).await?;
+                        return Err(Error::ClientAuthImpossible(username.into()));
+                    }
+
+                    let mut hash = (*pool.auth_hash.read()).clone();
+
+                    if hash.is_none() {
+                        warn!(
+                            "Query auth configured \
+                              but no hash password found \
+                              for pool {}. Will try to refetch it.",
+                            pool_name
+                        );
+
+                        match refetch_auth_hash(&pool).await {
+                            Ok(fetched_hash) => {
+                                warn!("Password for {}, obtained. Updating.", client_identifier);
+
+                                {
+                                    let mut pool_auth_hash = pool.auth_hash.write();
+                                    *pool_auth_hash = Some(fetched_hash.clone());
+                                }
+
+                                hash = Some(fetched_hash);
                             }
 
-                            hash = Some(fetched_hash);
-                        }
+                            Err(err) => {
+                                wrong_password(&mut write, username).await?;
 
-                        Err(err) => {
-                            wrong_password(&mut write, username).await?;
-
-                            return Err(Error::ClientAuthPassthroughError(
-                                err.to_string(),
-                                client_identifier,
-                            ));
+                                return Err(Error::ClientAuthPassthroughError(
+                                    err.to_string(),
+                                    client_identifier,
+                                ));
+                            }
                         }
-                    }
+                    };
+
+                    Some(md5_hash_second_pass(&hash.unwrap(), &salt))
                 };
 
-                Some(md5_hash_second_pass(&hash.unwrap(), &salt))
-            };
-
-            // Once we have the resulting hash, we compare with what the client gave us.
-            // If they do not match and auth query is set up, we try to refetch the hash one more time
-            // to see if the password has changed since the pool was created.
-            //
-            // @TODO: we could end up fetching again the same password twice (see above).
-            if password_hash.unwrap() != password_response {
-                warn!(
-                    "Invalid password {}, will try to refetch it.",
-                    client_identifier
-                );
-
-                let fetched_hash = match refetch_auth_hash(&pool).await {
-                    Ok(fetched_hash) => fetched_hash,
-                    Err(err) => {
-                        wrong_password(&mut write, username).await?;
-
-                        return Err(err);
-                    }
-                };
-
-                let new_password_hash = md5_hash_second_pass(&fetched_hash, &salt);
-
-                // Ok password changed in server an auth is possible.
-                if new_password_hash == password_response {
+                // Once we have the resulting hash, we compare with what the client gave us.
+                // If they do not match and auth query is set up, we try to refetch the hash one more time
+                // to see if the password has changed since the pool was created.
+                //
+                // @TODO: we could end up fetching again the same password twice (see above).
+                if password_hash.unwrap() != password_response {
                     warn!(
-                        "Password for {}, changed in server. Updating.",
+                        "Invalid password {}, will try to refetch it.",
                         client_identifier
                     );
 
-                    {
-                        let mut pool_auth_hash = pool.auth_hash.write();
-                        *pool_auth_hash = Some(fetched_hash);
+                    let fetched_hash = match refetch_auth_hash(&pool).await {
+                        Ok(fetched_hash) => fetched_hash,
+                        Err(err) => {
+                            wrong_password(&mut write, username).await?;
+
+                            return Err(err);
+                        }
+                    };
+
+                    let new_password_hash = md5_hash_second_pass(&fetched_hash, &salt);
+
+                    // Ok password changed in server an auth is possible.
+                    if new_password_hash == password_response {
+                        warn!(
+                            "Password for {}, changed in server. Updating.",
+                            client_identifier
+                        );
+
+                        {
+                            let mut pool_auth_hash = pool.auth_hash.write();
+                            *pool_auth_hash = Some(fetched_hash);
+                        }
+                    } else {
+                        wrong_password(&mut write, username).await?;
+                        return Err(Error::ClientGeneralError(
+                            "Invalid password".into(),
+                            client_identifier,
+                        ));
                     }
-                } else {
-                    wrong_password(&mut write, username).await?;
-                    return Err(Error::ClientGeneralError(
-                        "Invalid password".into(),
-                        client_identifier,
-                    ));
                 }
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,7 @@ impl Address {
 pub struct User {
     pub username: String,
     pub password: Option<String>,
+    pub auth_type: String,
     pub server_username: Option<String>,
     pub server_password: Option<String>,
     pub pool_size: u32,
@@ -225,6 +226,7 @@ impl Default for User {
         User {
             username: String::from("postgres"),
             password: None,
+            auth_type: "md5".to_string(),
             server_username: None,
             server_password: None,
             pool_size: 15,


### PR DESCRIPTION
This PR implements trust (no password) authentication with pgcat. Postgres offers a number of authentication options that are not available with pgcat with trust being the most basic. Added a configuration item to allow the auth_type to be set at the user level.