### PR TITLE
Add TCP_NODELAY option to improve performance for large response queries

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -733,6 +733,10 @@ pub fn configure_socket(stream: &TcpStream) {
         }
         Err(err) => error!("Could not configure socket: {}", err),
     }
+    match sock_ref.set_nodelay(true) {
+        Ok(_) => (),
+        Err(err) => error!("Could not configure TCP_NODELAY for socket: {}", err),
+    }
 }
 
 pub trait BytesMutReader {


### PR DESCRIPTION
This commit adds the TCP_NODELAY option to the socket configuration in `configure_socket` function. Without this option, we observed significant performance issues when executing SELECT queries with large responses.

Before the fix:
```
postgres=> SELECT repeat('a', 1); SELECT repeat('a', 8153); 
Time: 1.368 ms
Time: 41.364 ms
```
After the fix:
```
postgres=> SELECT repeat('a', 1); SELECT repeat('a', 8153);
Time: 1.332 ms
Time: 1.528 ms
```
By setting TCP_NODELAY, we eliminate the Nagle's algorithm delay, which results in a substantial improvement in response times for large queries.

This problem was discussed in https://github.com/postgresml/pgcat/issues/616.