### PR TITLE
Add STOPSIGNAL to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
 WORKDIR /etc/pgcat
 ENV RUST_LOG=info
 CMD ["pgcat"]
+STOPSIGNAL SIGINT


### PR DESCRIPTION
This documents that pgcat expects SIGINT for graceful shutdown. Kubernetes in particular sends a SIGTERM by default but will respect this flag and send a SIGINT if requested.