### PR TITLE
Add ExecReload option to pgcat.service for configuration reloads

### DIFF
--- a/pgcat.service
+++ b/pgcat.service
@@ -11,6 +11,7 @@ RestartSec=1
 Environment=RUST_LOG=info
 LimitNOFILE=65536
 ExecStart=/usr/bin/pgcat /etc/pgcat.toml
+ExecReload=/bin/kill -SIGHUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This commit adds the ExecReload option to the pgcat.service file, allowing for reloading the PgCat service configuration without restarting the service. This update enables the use of `sudo systemctl reload pgcat.service` for applying configuration changes more efficiently.

Before the fix:

The service configuration did not support the reload command, necessitating a full restart to apply any configuration changes, which could cause downtime and interrupt active connections.

After the fix:

The service configuration now includes the `ExecReload=/bin/kill -SIGHUP $MAINPID` option, allowing for seamless configuration reloads:

```ini
[Unit]
Description=PgCat pooler
After=network.target
StartLimitIntervalSec=0

[Service]
User=pgcat
Type=simple
Restart=always
RestartSec=1
Environment=RUST_LOG=info
LimitNOFILE=65536
ExecStart=/usr/bin/pgcat /etc/pgcat.toml
ExecReload=/bin/kill -SIGHUP $MAINPID

[Install]
WantedBy=multi-user.target