### PR TITLE
chore: bump rust to 1.79.0 in Dockerfile.ci

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM cimg/rust:1.67.1
+FROM cimg/rust:1.79.0
 COPY --from=sclevine/yj /bin/yj /bin/yj
 RUN /bin/yj -h
 RUN sudo apt-get update && \


### PR DESCRIPTION
The publish-ci-docker-image job is failing due to the old rust version;


https://github.com/postgresml/pgcat/actions/runs/9648527594/job/26609941534#step:4:2310
```
Caused by:
172.3   package `cargo-platform v0.1.8` cannot be built because it requires rustc 1.73 or newer, while the currently active rustc version is 1.67.1
```