### PR TITLE
Add server_tls to helm charts

### DIFF
--- a/charts/pgcat/templates/secret.yaml
+++ b/charts/pgcat/templates/secret.yaml
@@ -25,6 +25,10 @@ stringData:
     tcp_keepalives_idle = {{ .Values.configuration.general.tcp_keepalives_idle }}
     tcp_keepalives_count = {{ .Values.configuration.general.tcp_keepalives_count }}
     tcp_keepalives_interval = {{ .Values.configuration.general.tcp_keepalives_interval }}
+    server_tls = {{ .Values.configuration.general.server_tls }}
+    verify_server_certificate = {{ .Values.configuration.verify_server_certificate }}
+    dns_cache_enabled = {{ .Values.configuration.general.dns_cache_enabled }}
+    dns_max_ttl = {{ .Values.configuration.general.dns_max_ttl }}
     {{- if and (ne .Values.configuration.general.tls_certificate "-") (ne .Values.configuration.general.tls_private_key "-") }}
     tls_certificate = "{{ .Values.configuration.general.tls_certificate }}"
     tls_private_key = "{{ .Values.configuration.general.tls_private_key }}"

--- a/charts/pgcat/values.yaml
+++ b/charts/pgcat/values.yaml
@@ -235,6 +235,24 @@ configuration:
     # Number of seconds between keepalive packets.
     tcp_keepalives_interval: 5
 
+    # Enable TLS connections from PgCat to Postgres servers. Postgres has to be configured to support TLS,
+    # which is typical to be the case for Postgres distributed via package managers.
+    server_tls: false
+
+    # If server_tls is enabled, validate that the server certificate is valid. This disallows connections
+    # for self-signed certificates which haven't been added to the root store on the machines running PgCat.
+    verify_server_certificate: false
+
+    # If enabled, PgCat will resolve and cache DNS of Postgres servers, overriding default TTL provided by
+    # system DNS servers. This is useful when using DNS for configuring traffic routing to Postgres servers:
+    # if the IP resolved by the DNS query changed from its previously cached value, the connection pool will
+    # be automatically recreated with connections to the new Postgres server.
+    dns_cache_enabled: false
+
+    # Maximum number of seconds to keep cached DNS values. Once this timeout expires, a DNS refresh is
+    # performed against all targets in the cache.
+    dns_max_ttl: 30
+
   ## pool
   ## configs are structured as pool.<pool_name>
   ## the pool_name is what clients use as database name when connecting


### PR DESCRIPTION
Adds server_tls, server certificates, and dns to the helm chart with defaults based on docs currently on the site with their same defaults.

ref: https://postgresml.org/docs/open-source/pgcat/configuration#server-tls