### PR TITLE
Fix a Panic in admin commands

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -56,7 +56,7 @@ where
     let query_parts: Vec<&str> = query.trim_end_matches(';').split_whitespace().collect();
 
     match query_parts
-        .get(0)
+        .first()
         .unwrap_or(&"")
         .to_ascii_uppercase()
         .as_str()

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -55,7 +55,12 @@ where
 
     let query_parts: Vec<&str> = query.trim_end_matches(';').split_whitespace().collect();
 
-    match query_parts[0].to_ascii_uppercase().as_str() {
+    match query_parts
+        .get(0)
+        .unwrap_or(&"")
+        .to_ascii_uppercase()
+        .as_str()
+    {
         "BAN" => {
             trace!("BAN");
             ban(stream, query_parts).await

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -84,7 +84,12 @@ where
             trace!("SHUTDOWN");
             shutdown(stream).await
         }
-        "SHOW" => match query_parts[1].to_ascii_uppercase().as_str() {
+        "SHOW" => match query_parts
+            .get(1)
+            .unwrap_or(&"")
+            .to_ascii_uppercase()
+            .as_str()
+        {
             "HELP" => {
                 trace!("SHOW HELP");
                 show_help(stream).await

--- a/tests/ruby/admin_spec.rb
+++ b/tests/ruby/admin_spec.rb
@@ -91,6 +91,24 @@ describe "Admin" do
     end
   end
 
+  describe "SHOW " do
+    it "does not panic" do
+      admin_conn = PG::connect(processes.pgcat.admin_connection_string)
+      expect { admin_conn.async_exec("SHOW ") }.to raise_error(PG::SystemError).with_message(/FATAL:  Unsupported SHOW query against the admin database/)
+      admin_conn.close
+    end
+  end
+
+  describe "SHOW <WRONG COMMAND>" do
+    it "does not panic" do
+      admin_conn = PG::connect(processes.pgcat.admin_connection_string)
+      ["ME THE MONEY", "ME THE WAY", "UP", "TIME"].each do |cmd|
+        expect { admin_conn.async_exec("SHOW #{cmd}") }.to raise_error(PG::SystemError).with_message(/FATAL:  Unsupported SHOW query against the admin database/)
+      end
+      admin_conn.close
+    end
+  end
+
   describe "PAUSE" do
     it "pauses all pools" do
       admin_conn = PG::connect(processes.pgcat.admin_connection_string)

--- a/tests/ruby/admin_spec.rb
+++ b/tests/ruby/admin_spec.rb
@@ -91,21 +91,24 @@ describe "Admin" do
     end
   end
 
-  describe "SHOW " do
-    it "does not panic" do
-      admin_conn = PG::connect(processes.pgcat.admin_connection_string)
-      expect { admin_conn.async_exec("SHOW ") }.to raise_error(PG::SystemError).with_message(/FATAL:  Unsupported SHOW query against the admin database/)
-      admin_conn.close
-    end
-  end
-
-  describe "SHOW <WRONG COMMAND>" do
-    it "does not panic" do
-      admin_conn = PG::connect(processes.pgcat.admin_connection_string)
-      ["ME THE MONEY", "ME THE WAY", "UP", "TIME"].each do |cmd|
-        expect { admin_conn.async_exec("SHOW #{cmd}") }.to raise_error(PG::SystemError).with_message(/FATAL:  Unsupported SHOW query against the admin database/)
+  [
+    "SHOW ME THE MONEY", 
+    "SHOW ME THE WAY", 
+    "SHOW UP", 
+    "SHOWTIME",
+    "HAMMER TIME",
+    "SHOWN TO BE TRUE",
+    "SHOW ",
+    "SHOW     ",
+    "SHOW 1",
+    ";;;;;"
+  ].each do |cmd|
+    describe "Bad command #{cmd}" do
+      it "does not panic and responds with PG::SystemError" do
+        admin_conn = PG::connect(processes.pgcat.admin_connection_string)
+        expect { admin_conn.async_exec(cmd) }.to raise_error(PG::SystemError).with_message(/Unsupported/)
+        admin_conn.close
       end
-      admin_conn.close
     end
   end
 


### PR DESCRIPTION
We have a panic when we send `SHOW ` or `;;;;;;;;;;;;;;;;;` to admin database.

This PR fixes these panics and adds a couple of tests