### PR TITLE
Improve Prometheus exporter output

### DIFF
--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -203,7 +203,7 @@ impl<Value: fmt::Display> PrometheusMetric<Value> {
         labels.insert("role", address.role.to_string());
         labels.insert("pool", address.pool_name.clone());
         labels.insert("database", address.database.to_string());
-        labels.insert("username",  address.username.clone());
+        labels.insert("username", address.username.clone());
 
         Self::from_name(&format!("databases_{}", name), value, labels)
     }
@@ -219,7 +219,7 @@ impl<Value: fmt::Display> PrometheusMetric<Value> {
         labels.insert("role", address.role.to_string());
         labels.insert("pool", address.pool_name.clone());
         labels.insert("database", address.database.to_string());
-        labels.insert("username",  address.username.clone());
+        labels.insert("username", address.username.clone());
 
         Self::from_name(&format!("servers_{}", name), value, labels)
     }
@@ -231,7 +231,7 @@ impl<Value: fmt::Display> PrometheusMetric<Value> {
         labels.insert("pool", address.pool_name.clone());
         labels.insert("role", address.role.to_string());
         labels.insert("database", address.database.to_string());
-        labels.insert("username",  address.username.clone());
+        labels.insert("username", address.username.clone());
 
         Self::from_name(&format!("stats_{}", name), value, labels)
     }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -297,7 +297,7 @@ fn push_address_stats(lines: &mut Vec<String>) {
         }
     }
     for (_key, metrics) in grouped_metrics {
-        if metrics.len() > 0 {
+        if !metrics.is_empty() {
             lines.push(metrics[0].get_header());
             for metric in metrics {
                 lines.push(metric.to_string());
@@ -325,7 +325,7 @@ fn push_pool_stats(lines: &mut Vec<String>) {
         }
     }
     for (_key, metrics) in grouped_metrics {
-        if metrics.len() > 0 {
+        if !metrics.is_empty() {
             lines.push(metrics[0].get_header());
             for metric in metrics {
                 lines.push(metric.to_string());
@@ -363,7 +363,7 @@ fn push_database_stats(lines: &mut Vec<String>) {
         }
     }
     for (_key, metrics) in grouped_metrics {
-        if metrics.len() > 0 {
+        if !metrics.is_empty() {
             lines.push(metrics[0].get_header());
             for metric in metrics {
                 lines.push(metric.to_string());
@@ -421,7 +421,7 @@ fn push_server_stats(lines: &mut Vec<String>) {
         }
     }
     for (_key, metrics) in grouped_metrics {
-        if metrics.len() > 0 {
+        if !metrics.is_empty() {
             lines.push(metrics[0].get_header());
             for metric in metrics {
                 lines.push(metric.to_string());

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -334,7 +334,7 @@ fn push_address_stats(lines: &mut Vec<String>) {
                     {
                         grouped_metrics
                             .entry(key)
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push(prometheus_metric);
                     } else {
                         debug!("Metric {} not implemented for {}", key, address.name());
@@ -364,7 +364,7 @@ fn push_pool_stats(lines: &mut Vec<String>) {
             {
                 grouped_metrics
                     .entry(name)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(prometheus_metric);
             } else {
                 debug!("Metric {} not implemented for ({})", name, *pool_id);
@@ -400,7 +400,7 @@ fn push_database_stats(lines: &mut Vec<String>) {
                     {
                         grouped_metrics
                             .entry(key.to_string())
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push(prometheus_metric);
                     } else {
                         debug!("Metric {} not implemented for {}", key, address.name());
@@ -474,7 +474,7 @@ fn push_server_stats(lines: &mut Vec<String>) {
                         {
                             grouped_metrics
                                 .entry(key.to_string())
-                                .or_insert_with(Vec::new)
+                                .or_default()
                                 .push(prometheus_metric);
                         } else {
                             debug!("Metric {} not implemented for {}", key, address.name());


### PR DESCRIPTION
This is a merge PR that combines https://github.com/postgresml/pgcat/pull/745 and https://github.com/postgresml/pgcat/pull/662. 

# Description from 662
- Add username label to deconflict metrics that would otherwise have duplicate labels across different pools.
- Group metrics by name and only print HELP and TYPE once per metric name.
- Sort labels for a deterministic output.

This PR fixes https://github.com/postgresml/pgcat/issues/563

Without this change, having multiple users results in Prometheus processing errors downstream along the lines of:

> second HELP line for metric name \"pgcat_stats_total_xact_count\"

### Prometheus Reference

https://prometheus.io/docs/instrumenting/exposition_formats/#grouping-and-sorting

> Grouping and sorting
> 
> All lines for a given metric must be provided as one single group, with the optional HELP and TYPE lines first (in no particular order). Beyond that, reproducible sorting in repeated expositions is preferred but not required, i.e. do not sort if the computational cost is prohibitive.
> 
> Each line must have a unique combination of a metric name and labels. Otherwise, the ingestion behavior is undefined.

### Example setup

In the example below, I tested with an extra user defined in `examples/docker/pgcat.toml`, e.g.

```toml
[pools.postgres.users.0]
username = "postgres"
password = "postgres"
pool_size = 9

[pools.postgres.users.1]
username = "curtis"
password = "abcd1234"
pool_size = 9
```

### Example Output: Before

Using `pgcat_stats_total_xact_count` as an example, to cull down the overall amount of text I'm pasting here.

```shell
$ cat metrics_before_fix.txt | grep pgcat_stats_total_xact_count
```

```
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{role="primary",database="postgres",shard="0",host="postgres",pool="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{role="replica",host="postgres",database="postgres",pool="postgres",shard="0"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{shard="1",host="postgres",role="primary",database="postgres",pool="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{role="replica",pool="postgres",shard="1",database="postgres",host="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{shard="2",role="primary",host="postgres",pool="postgres",database="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{host="postgres",shard="2",pool="postgres",database="postgres",role="replica"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{host="postgres",role="primary",database="postgres",pool="postgres",shard="0"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{host="postgres",role="replica",database="postgres",pool="postgres",shard="0"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{host="postgres",shard="1",role="primary",database="postgres",pool="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{role="replica",database="postgres",shard="1",pool="postgres",host="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{database="postgres",shard="2",role="primary",host="postgres",pool="postgres"} 0
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{database="postgres",pool="postgres",host="postgres",shard="2",role="replica"} 0
```

### Example Output: After

```shell
$ cat metrics_after_fix.txt | grep pgcat_stats_total_xact_count
```

```
# HELP pgcat_stats_total_xact_count Total number of transactions started by the client
# TYPE pgcat_stats_total_xact_count counter
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="primary",shard="0",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="0",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="primary",shard="1",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="1",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="primary",shard="2",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="2",username="curtis"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="primary",shard="0",username="postgres"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="0",username="postgres"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="po```stgres",role="primary",shard="1",username="postgres"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="1",username="postgres"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="primary",shard="2",username="postgres"} 0
pgcat_stats_total_xact_count{database="postgres",host="postgres",pool="postgres",role="replica",shard="2",username="postgres"} 0
```

## Description from 745
This PR contains cherry-picked commits from [this](https://github.com/postgresml/pgcat/pull/662) PR.

