### PR TITLE
Track transaction time

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1091,6 +1091,7 @@ where
             //
             // If the client is in session mode, no more custom protocol
             // commands will be accepted.
+            let transaction_start = Instant::now();
             loop {
                 let message = match initial_message {
                     None => {
@@ -1204,9 +1205,10 @@ where
                         if !server.in_transaction() {
                             // Report transaction executed statistics.
                             self.stats.transaction();
-                            server
-                                .stats()
-                                .transaction(self.server_parameters.get_application_name());
+                            server.stats().transaction(
+                                Instant::now().duration_since(transaction_start).as_millis() as u64,
+                                self.server_parameters.get_application_name(),
+                            );
 
                             // Release server back to the pool if we are in transaction mode.
                             // If we are in session mode, we keep the server until the client disconnects.
@@ -1460,9 +1462,10 @@ where
 
                         if !server.in_transaction() {
                             self.stats.transaction();
-                            server
-                                .stats()
-                                .transaction(self.server_parameters.get_application_name());
+                            server.stats().transaction(
+                                Instant::now().duration_since(transaction_start).as_millis() as u64,
+                                self.server_parameters.get_application_name(),
+                            );
 
                             // Release server back to the pool if we are in transaction mode.
                             // If we are in session mode, we keep the server until the client disconnects.
@@ -1511,9 +1514,10 @@ where
 
                         if !server.in_transaction() {
                             self.stats.transaction();
-                            server
-                                .stats()
-                                .transaction(self.server_parameters.get_application_name());
+                            server.stats().transaction(
+                                Instant::now().duration_since(transaction_start).as_millis() as u64,
+                                self.server_parameters.get_application_name(),
+                            );
 
                             // Release server back to the pool if we are in transaction mode.
                             // If we are in session mode, we keep the server until the client disconnects.

--- a/src/stats/server.rs
+++ b/src/stats/server.rs
@@ -187,11 +187,12 @@ impl ServerStats {
     /// we report each individual queries outside a transaction as a transaction
     /// We only count the initial BEGIN as a transaction, all queries within do not
     /// count as transactions
-    pub fn transaction(&self, application_name: &str) {
+    pub fn transaction(&self, milliseconds: u64, application_name: &str) {
         self.set_application(application_name.to_string());
 
         self.transaction_count.fetch_add(1, Ordering::Relaxed);
         self.address.stats.xact_count_add();
+        self.address.stats.xact_time_add(milliseconds);
     }
 
     /// Report data sent to a server


### PR DESCRIPTION
~~I'm not sure if this is the correct way to track it (on the server, with an always-outdated timestamp), but I couldn't see an obvious way to track this on the client side, and logically a transaction must be tied to a particular server connection, right?~~ Now tracking on the client side.

Closes https://github.com/postgresml/pgcat/issues/114 (`total_query_time` is already implemented).