### PR TITLE
Fix Ruby tests

### DIFF
--- a/tests/ruby/Gemfile.lock
+++ b/tests/ruby/Gemfile.lock
@@ -1,18 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activerecord (3.2.14)
-    activesupport (7.0.7.1)
+    activemodel (7.1.4)
+      activesupport (= 7.1.4)
+    activerecord (7.1.4)
+      activemodel (= 7.1.4)
+      activesupport (= 7.1.4)
+      timeout (>= 0.4.0)
+    activesupport (7.1.4)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
     concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
+    drb (2.2.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     minitest (5.25.1)
+    mutex_m (0.2.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -48,6 +63,7 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     strscan (3.1.0)
+    timeout (0.4.1)
     toml (0.3.0)
       parslet (>= 1.8.0, < 3.0.0)
     toxiproxy (2.0.1)


### PR DESCRIPTION
Build is failing with this error
```
Downloading activerecord-3.2.14 revealed dependencies not in the API or the
lockfile (activesupport (= 3.2.14), activemodel (= 3.2.14), arel (~> 3.0.2),
tzinfo (~> 0.3.29)).
Either installing with `--full-index` or running `bundle update activerecord`
should fix the problem.
```
After ActiveSupport was updated.

This PR fixes that