### PR TITLE
End Prometheus stats with a new line separator

### DIFF
--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -309,6 +309,7 @@ async fn prometheus_stats(
             push_pool_stats(&mut lines);
             push_server_stats(&mut lines);
             push_database_stats(&mut lines);
+            lines.push("".to_string()); // Ensure to end the stats with a line terminator as required by the specification.
 
             Response::builder()
                 .header("content-type", "text/plain; version=0.0.4")


### PR DESCRIPTION
According to the [OpenMetrics specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#overall-structure), each line MUST end with `\n`. Previously, the last line was not ending with `\n`, so that strict parsers had issues reading the Prometheus stats.

I did not add any tests since I am not too comfortable with Rust and pgCat. Feel free to continue my work in this regard.