### PR TITLE
[Helm] Fix for passing pool config `query_parser_enabled`, `query_parser_read_write_splitting` and `primary_reads_enabled` as false

### DIFF
--- a/charts/pgcat/templates/secret.yaml
+++ b/charts/pgcat/templates/secret.yaml
@@ -48,9 +48,9 @@ stringData:
     load_balancing_mode = {{ default "random" $pool.load_balancing_mode | quote }}
     default_role = {{ default "any" $pool.default_role | quote }}
     prepared_statements_cache_size = {{ default 500 $pool.prepared_statements_cache_size }}
-    query_parser_enabled = {{ default true $pool.query_parser_enabled }}
-    query_parser_read_write_splitting = {{ default true $pool.query_parser_read_write_splitting }}
-    primary_reads_enabled = {{ default true $pool.primary_reads_enabled }}
+    query_parser_enabled = {{ ne $pool.query_parser_enabled false }}
+    query_parser_read_write_splitting = {{ ne $pool.query_parser_read_write_splitting false }}
+    primary_reads_enabled = {{ ne $pool.primary_reads_enabled false }}
     sharding_function = {{ default "pg_bigint_hash" $pool.sharding_function | quote }}
 
     {{-   range $index, $user := $pool.users }}


### PR DESCRIPTION
as when using `default` the value `false` was treated as, well, falsy, and the default value of `true` was applied...

See https://github.com/helm/helm/issues/3308 and
https://stackoverflow.com/q/66265193/2693875 for
more context