### PR TITLE
Fix `default_role` being ignored when `query_parser_enabled` was false

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -881,6 +881,7 @@ where
         };
 
         query_router.update_pool_settings(&pool.settings);
+        query_router.set_default_role();
 
         // Our custom protocol loop.
         // We expect the client to either start a transaction with regular queries

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1061,6 +1061,11 @@ impl QueryRouter {
         self.active_shard
     }
 
+    /// Set active_role as the default_role specified in the pool.
+    pub fn set_default_role(&mut self) {
+        self.active_role = self.pool_settings.default_role;
+    }
+
     /// Get the current desired server role we should be talking to.
     pub fn role(&self) -> Option<Role> {
         self.active_role


### PR DESCRIPTION
`default_role` was ignored when `query_parser_enabled` was set to false, this was because `update_pool_settings` does not populate active_role field in `query_router` struct. The fix is simple, I just set it when the router is configured for the first time.

Note that as of this, what we say in docs:

```

### default_role
` ` ` 
path: pools.<pool_name>.default_role
default: "any"
` ` ` 

If the client doesn't specify, PgCat routes traffic to this role by default.
`any` round-robin between primary and replicas,
`replica` round-robin between replicas only without touching the primary,
`primary` all queries go to the primary unless otherwise specified.
```

is incorrect, because without the fix (and `query_parser_enabled` set to false), this is always treated as `any` (which touches the primary as well as the replicas).

