### PR TITLE
Fixing invalid setting name in pgcat.toml

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -179,7 +179,7 @@ primary_reads_enabled = true
 # `random`: picks a shard at random
 # `random_healthy`: picks a shard at random favoring shards with the least number of recent errors
 # `shard_<number>`: e.g. shard_0, shard_4, etc. picks a specific shard, everytime
-# no_shard_specified_behavior = "shard_0"
+# default_shard = "shard_0"
 
 # So what if you wanted to implement a different hashing function,
 # or you've already built one and you want this pooler to use it?


### PR DESCRIPTION
Fixing small documentation problem described in https://github.com/postgresml/pgcat/issues/848.
