### PR TITLE
Implemented PGBouncer like database Proxy functionality using Auth_Query

### DIFF
--- a/pgcat.proxy.toml
+++ b/pgcat.proxy.toml
@@ -1,0 +1,33 @@
+# This is an example of the most basic config
+# that will mimic what PgBouncer does in transaction mode with one server.
+
+[general]
+
+log_level = "DEBUG"
+
+host = "0.0.0.0"
+port = 6433
+admin_username = "pgcat"
+admin_password = "pgcat"
+
+[pools.pgml]
+auth_query="SELECT usename, passwd FROM pg_shadow WHERE usename='$1'"
+
+# Be sure to grant this user LOGIN on Postgres
+auth_query_user = "postgres"
+auth_query_password = "postgres"
+
+proxy = true
+
+[pools.pgml.users.0]
+username = "postgres"
+#password = "postgres"
+pool_size = 10
+min_pool_size = 1
+pool_mode = "session"
+
+[pools.pgml.shards.0]
+servers = [
+  ["localhost", 5432, "primary"]
+]
+database = "postgres"

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,7 +20,7 @@ use crate::config::{
 use crate::constants::*;
 use crate::messages::*;
 use crate::plugins::PluginOutput;
-use crate::pool::{get_pool, ClientServerMap, ConnectionPool};
+use crate::pool::{get_pool, get_or_create_pool, ClientServerMap, ConnectionPool};
 use crate::query_router::{Command, QueryRouter};
 use crate::server::{Server, ServerParameters};
 use crate::stats::{ClientStats, ServerStats};
@@ -557,7 +557,7 @@ where
         }
         // Authenticate normal user.
         else {
-            let pool = match get_pool(pool_name, username) {
+            let pool = match get_or_create_pool(pool_name, username).await {
                 Some(pool) => pool,
                 None => {
                     error_response(

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,7 +20,7 @@ use crate::config::{
 use crate::constants::*;
 use crate::messages::*;
 use crate::plugins::PluginOutput;
-use crate::pool::{get_pool, get_or_create_pool, ClientServerMap, ConnectionPool};
+use crate::pool::{get_or_create_pool, get_pool, ClientServerMap, ConnectionPool};
 use crate::query_router::{Command, QueryRouter};
 use crate::server::{Server, ServerParameters};
 use crate::stats::{ClientStats, ServerStats};

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,7 +589,6 @@ pub struct Pool {
     #[serde(default = "Pool::default_prepared_statements_cache_size")]
     pub prepared_statements_cache_size: usize,
 
-
     #[serde(default = "Pool::default_proxy")]
     pub proxy: bool,
 
@@ -646,7 +645,9 @@ impl Pool {
         0
     }
 
-    pub fn default_proxy() -> bool {false}
+    pub fn default_proxy() -> bool {
+        false
+    }
 
     pub fn validate(&mut self) -> Result<(), Error> {
         match self.default_role.as_ref() {
@@ -1235,7 +1236,8 @@ impl Config {
                 pool_name,
                 pool_config.pool_mode.to_string()
             );
-            info!("[pool: {}] Proxy mode: {}",
+            info!(
+                "[pool: {}] Proxy mode: {}",
                 pool_name,
                 pool_config.proxy.to_string()
             );

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,6 +589,10 @@ pub struct Pool {
     #[serde(default = "Pool::default_prepared_statements_cache_size")]
     pub prepared_statements_cache_size: usize,
 
+
+    #[serde(default = "Pool::default_proxy")]
+    pub proxy: bool,
+
     pub plugins: Option<Plugins>,
     pub shards: BTreeMap<String, Shard>,
     pub users: BTreeMap<String, User>,
@@ -641,6 +645,8 @@ impl Pool {
     pub fn default_prepared_statements_cache_size() -> usize {
         0
     }
+
+    pub fn default_proxy() -> bool {false}
 
     pub fn validate(&mut self) -> Result<(), Error> {
         match self.default_role.as_ref() {
@@ -753,6 +759,7 @@ impl Default for Pool {
             cleanup_server_connections: true,
             log_client_parameter_status_changes: false,
             prepared_statements_cache_size: Self::default_prepared_statements_cache_size(),
+            proxy: Self::default_proxy(),
             plugins: None,
             shards: BTreeMap::from([(String::from("1"), Shard::default())]),
             users: BTreeMap::default(),
@@ -1227,6 +1234,10 @@ impl Config {
                 "[pool: {}] Default pool mode: {}",
                 pool_name,
                 pool_config.pool_mode.to_string()
+            );
+            info!("[pool: {}] Proxy mode: {}",
+                pool_name,
+                pool_config.proxy.to_string()
             );
             info!(
                 "[pool: {}] Load Balancing mode: {:?}",


### PR DESCRIPTION
Implemented PGBouncer like database Proxy functionality using Auth_Query

The new implementation behavior is as follows, 
For any pool, if `proxy` configuration is made true, the pool would not initialize on the pgcat startup, 
on the first connection, pgcat would connect to the PostgreSQL cluster using `auth_query` and retrieve a password hash and established pool on the fly,

This implementation fixes the following issues. 
#443, #509, #828 

Following PR #521, #631 should marge to enhance this implementation,  

Use `pgcat.proxy.toml` as a configuration sample. 

Added new configuration ```proxy``` variable per pool to indicate this is pgbouncer like proxy behaviour and would use ```auth_query``` base login. 

I am doing Rust programming for the first time, so I see many code improvements in this implementation. Also, I have made a lot of duplicate code to implement this functionality.

Please review the code and suggest any changes to make this PR ready to merge.

Feel free to ask any questions on this implementation.
