### PR TITLE
Add 'Fail' mode when no shard selected

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -179,6 +179,7 @@ primary_reads_enabled = true
 # `random`: picks a shard at random
 # `random_healthy`: picks a shard at random favoring shards with the least number of recent errors
 # `shard_<number>`: e.g. shard_0, shard_4, etc. picks a specific shard, everytime
+# `fail`: fails to pick up shard. (require explicit shard setup)
 # default_shard = "shard_0"
 
 # So what if you wanted to implement a different hashing function,

--- a/src/config.rs
+++ b/src/config.rs
@@ -773,6 +773,7 @@ pub enum DefaultShard {
     Shard(usize),
     Random,
     RandomHealthy,
+    Fail
 }
 impl Default for DefaultShard {
     fn default() -> Self {
@@ -787,6 +788,7 @@ impl serde::Serialize for DefaultShard {
             }
             DefaultShard::Random => serializer.serialize_str("random"),
             DefaultShard::RandomHealthy => serializer.serialize_str("random_healthy"),
+            DefaultShard::Fail => serializer.serialize_str("fail"),
         }
     }
 }
@@ -804,6 +806,7 @@ impl<'de> serde::Deserialize<'de> for DefaultShard {
         match s.as_str() {
             "random" => Ok(DefaultShard::Random),
             "random_healthy" => Ok(DefaultShard::RandomHealthy),
+            "fail" => Ok(DefaultShard::Fail),
             _ => Err(serde::de::Error::custom(
                 "invalid value for no_shard_specified_behavior",
             )),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,7 @@ pub enum Error {
     QueryRouterError(String),
     InvalidShardId(usize),
     PreparedStatementError,
+    NoShardSelected
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -719,7 +719,8 @@ impl ConnectionPool {
                             .partial_cmp(&a.error_count.load(Ordering::Relaxed))
                             .unwrap()
                     });
-                }
+                },
+                DefaultShard::Fail => return Err(Error::NoShardSelected)
             },
         };
 


### PR DESCRIPTION
Implementation for feature request & proposed solution in https://github.com/postgresml/pgcat/issues/858.

Adds new option for `default_shard`.

