### PR TITLE
Add & fix helm metrics endpoint

### DIFF
--- a/charts/pgcat/Chart.yaml
+++ b/charts/pgcat/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: PostgresML
     email: team@postgresml.org
 appVersion: "1.2.0"
-version: 0.2.5
+version: 0.2.6

--- a/charts/pgcat/Chart.yaml
+++ b/charts/pgcat/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: PostgresML
     email: team@postgresml.org
 appVersion: "1.2.0"
-version: 0.2.6
+version: 0.3.0

--- a/charts/pgcat/templates/deployment.yaml
+++ b/charts/pgcat/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             - name: pgcat
               containerPort: {{ .Values.configuration.general.port }}
               protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.configuration.general.prometheus_exporter_port }}
+              protocol: TCP
           livenessProbe:
             tcpSocket:
               port: pgcat

--- a/charts/pgcat/templates/prometheus_exporter.yaml
+++ b/charts/pgcat/templates/prometheus_exporter.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configuration.general.enable_prometheus_exporter }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -14,3 +15,4 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: pgcat
       app.kubernetes.io/name: pgcat
+{{- end }}

--- a/charts/pgcat/templates/prometheus_exporter.yaml
+++ b/charts/pgcat/templates/prometheus_exporter.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "pgcat.fullname" . }}
+  labels:
+    {{- include "pgcat.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+    - interval: 10s
+      path: /metrics
+      scheme: http
+      targetPort: {{ .Values.configuration.general.prometheus_exporter_port }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: pgcat
+      app.kubernetes.io/name: pgcat

--- a/charts/pgcat/templates/service.yaml
+++ b/charts/pgcat/templates/service.yaml
@@ -11,9 +11,5 @@ spec:
       targetPort: pgcat
       protocol: TCP
       name: pgcat
-    - port: {{ .Values.configuration.general.prometheus_exporter_port }}
-      targetPort: metrics
-      protocol: TCP
-      name: metrics
   selector:
     {{- include "pgcat.selectorLabels" . | nindent 4 }}

--- a/charts/pgcat/templates/service.yaml
+++ b/charts/pgcat/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: pgcat
       protocol: TCP
       name: pgcat
+    - port: {{ .Values.configuration.general.prometheus_exporter_port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "pgcat.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
The existing declaration does not expose the deployment to collect metrics from the pods, hence no metrics are being collected.

This PR exposes the metrics port, and also includes a "for-convenience" PodMonitor.
As some of us may already have metrics setup, I bumped the semver by 1 minor version to prevent anyone accidentally updating & wiping their configs.