### PR TITLE
(feat) add audit logging plugin

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -878,25 +878,13 @@ impl Default for Shard {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Hash, Eq)]
 pub struct Plugins {
     pub intercept: Option<Intercept>,
     pub table_access: Option<TableAccess>,
     pub query_logger: Option<QueryLogger>,
     pub audit_logger: Option<AuditLogger>,
     pub prewarmer: Option<Prewarmer>,
-}
-
-impl Default for Plugins {
-    fn default() -> Self {
-        Self {
-            intercept: None,
-            table_access: None,
-            query_logger: None,
-            audit_logger: None,
-            prewarmer: None,
-        }
-    }
 }
 
 pub trait Plugin {

--- a/src/config.rs
+++ b/src/config.rs
@@ -878,13 +878,25 @@ impl Default for Shard {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Hash, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
 pub struct Plugins {
     pub intercept: Option<Intercept>,
     pub table_access: Option<TableAccess>,
     pub query_logger: Option<QueryLogger>,
     pub audit_logger: Option<AuditLogger>,
     pub prewarmer: Option<Prewarmer>,
+}
+
+impl Default for Plugins {
+    fn default() -> Self {
+        Self {
+            intercept: None,
+            table_access: None,
+            query_logger: None,
+            audit_logger: None,
+            prewarmer: None,
+        }
+    }
 }
 
 pub trait Plugin {
@@ -948,6 +960,12 @@ pub struct AuditLogger {
 }
 
 impl Plugin for QueryLogger {
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+impl Plugin for AuditLogger {
     fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -883,6 +883,7 @@ pub struct Plugins {
     pub intercept: Option<Intercept>,
     pub table_access: Option<TableAccess>,
     pub query_logger: Option<QueryLogger>,
+    pub audit_logger: Option<AuditLogger>,
     pub prewarmer: Option<Prewarmer>,
 }
 
@@ -901,10 +902,11 @@ impl std::fmt::Display for Plugins {
         }
         write!(
             f,
-            "interceptor: {}, table_access: {}, query_logger: {}, prewarmer: {}",
+            "interceptor: {}, table_access: {}, query_logger: {}, audit_logger: {}, prewarmer: {}",
             is_enabled(self.intercept.as_ref()),
             is_enabled(self.table_access.as_ref()),
             is_enabled(self.query_logger.as_ref()),
+            is_enabled(self.audit_logger.as_ref()),
             is_enabled(self.prewarmer.as_ref()),
         )
     }
@@ -937,6 +939,12 @@ impl Plugin for TableAccess {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Hash, Eq)]
 pub struct QueryLogger {
     pub enabled: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, Hash, Eq)]
+pub struct AuditLogger {
+    pub enabled: bool,
+    pub patterns: Vec<String>,
 }
 
 impl Plugin for QueryLogger {

--- a/src/plugins/audit_logger.rs
+++ b/src/plugins/audit_logger.rs
@@ -25,7 +25,7 @@ impl<'a> AuditLogger<'a> {
             .iter()
             .map(|p| Regex::new(p))
             .collect::<Result<Vec<Regex>, regex::Error>>()
-            .map_err(|e| Error::BadConfig)?;
+            .map_err(|_e| Error::BadConfig)?;
 
         Ok(AuditLogger {
             enabled,

--- a/src/plugins/audit_logger.rs
+++ b/src/plugins/audit_logger.rs
@@ -1,0 +1,71 @@
+//! Plugin for sanitizing and logging queries and their results
+//! Replaces sensitive data matching configured regex patterns with <REDACTED>
+
+use async_trait::async_trait;
+use log::info;
+use regex::Regex;
+use sqlparser::ast::Statement;
+
+use crate::{
+    errors::Error,
+    plugins::{Plugin, PluginOutput},
+    query_router::QueryRouter,
+};
+
+#[derive(Clone)]
+pub struct AuditLogger<'a> {
+    pub enabled: bool,
+    pub patterns: &'a Vec<String>,
+    compiled_patterns: Vec<Regex>,
+}
+
+impl<'a> AuditLogger<'a> {
+    pub fn new(enabled: bool, patterns: &'a Vec<String>) -> Result<Self, Error> {
+        let compiled_patterns = patterns
+            .iter()
+            .map(|p| Regex::new(p))
+            .collect::<Result<Vec<Regex>, regex::Error>>()
+            .map_err(|e| Error::BadConfig)?;
+
+        Ok(AuditLogger {
+            enabled,
+            patterns,
+            compiled_patterns,
+        })
+    }
+
+    fn sanitize(&self, text: &str) -> String {
+        let mut sanitized = text.to_string();
+        for pattern in &self.compiled_patterns {
+            sanitized = pattern.replace_all(&sanitized, "<REDACTED>").to_string();
+        }
+        sanitized
+    }
+}
+
+#[async_trait]
+impl<'a> Plugin for AuditLogger<'a> {
+    async fn run(
+        &mut self,
+        query_router: &QueryRouter,
+        ast: &Vec<Statement>,
+    ) -> Result<PluginOutput, Error> {
+        if !self.enabled {
+            return Ok(PluginOutput::Allow);
+        }
+
+        // Log sanitized queries
+        for stmt in ast {
+            let query = stmt.to_string();
+            let sanitized = self.sanitize(&query);
+            info!(
+                "[pool: {}][user: {}] Query: {}",
+                query_router.pool_settings().db,
+                query_router.pool_settings().user.username,
+                sanitized
+            );
+        }
+
+        Ok(PluginOutput::Allow)
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -8,10 +8,10 @@
 //!   - etc
 //!
 
+pub mod audit_logger;
 pub mod intercept;
 pub mod prewarmer;
 pub mod query_logger;
-pub mod audit_logger;
 pub mod table_access;
 
 use crate::{errors::Error, query_router::QueryRouter};
@@ -19,9 +19,9 @@ use async_trait::async_trait;
 use bytes::BytesMut;
 use sqlparser::ast::Statement;
 
+pub use audit_logger::AuditLogger;
 pub use intercept::Intercept;
 pub use query_logger::QueryLogger;
-pub use audit_logger::AuditLogger;
 pub use table_access::TableAccess;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,7 @@
 pub mod intercept;
 pub mod prewarmer;
 pub mod query_logger;
+pub mod audit_logger;
 pub mod table_access;
 
 use crate::{errors::Error, query_router::QueryRouter};
@@ -20,6 +21,7 @@ use sqlparser::ast::Statement;
 
 pub use intercept::Intercept;
 pub use query_logger::QueryLogger;
+pub use audit_logger::AuditLogger;
 pub use table_access::TableAccess;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -1916,6 +1916,7 @@ mod test {
         let plugins = Plugins {
             table_access: Some(table_access),
             intercept: None,
+            audit_logger: None,
             query_logger: None,
             prewarmer: None,
         };


### PR DESCRIPTION
This creates a method for audit logging with scrubbing. This is useful for highly controlled environments where any human interaction with a database needs to be logged for potential review. 

Example config:
``` 
[pools.mypool.plugins.query_sanitizer]                                                                          
 enabled = true                                                                                                  
 patterns = [                                                                                                    
   "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b", # Credit card numbers
   "^(?!666|000|9\\d{2})\\d{3}-(?!00)\\d{2}-(?!0{4})\\d{4}$", # Social Security Numbers
   "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b" # Email addresses                                     
 ] 