### PR TITLE
upgraded from 1.79.0 to 1.81

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.79.0-slim-bookworm AS builder
+FROM rust:1.81.0-slim-bookworm AS builder
 
 RUN apt-get update && \
     apt-get install -y build-essential


### PR DESCRIPTION
changed docker from from `rust:1.79.0-slim-bookworm` to `rust:1.81.0-slim-bookworm`.

Tests:
Ran the following benchmarks:

```
PGPASSWORD=postgres pgbench -i -h 127.0.0.1 -p 6432 -U postgres -d postgres && \
PGPASSWORD=postgres pgbench -t 1000 -h 127.0.0.1 -p 6432 -U postgres --protocol simple -d postgres && \
PGPASSWORD=postgres pgbench -t 1000 -h 127.0.0.1 -p 6432 -U postgres --protocol extended -d postgres
```

With
`docker-compose up --build` with `FROM rust:1.79.0-slim-bookworm AS builder`
```
scaling factor: 1
query mode: extended
number of clients: 1
number of threads: 1
number of transactions per client: 1000
number of transactions actually processed: 1000/1000
latency average = 1.339 ms
initial connection time = 0.473 ms
tps = 746.800892 (without initial connection time)
```

`docker-compose up --build` with `FROM rust:1.81.0-slim-bookworm AS builder`
```
scaling factor: 1
query mode: extended
number of clients: 1
number of threads: 1
number of transactions per client: 1000
number of transactions actually processed: 1000/1000
latency average = 1.363 ms
initial connection time = 0.633 ms
tps = 733.551932 (without initial connection time)
```
For `docker compose up --exit-code-from main`

```
main-1  | Generating coverage report
main-1  | error: /app/pgcat-*.profraw: No such file or directory
main-1  | error: /app/pgcat.profdata: could not read profile data!No such file or directory
main-1  | genhtml: ERROR: no valid records found in tracefile lcov.info
main-1  | Reading data file lcov.info
main-1  | rm: cannot remove '/app/*.profraw': No such file or directory
main-1  | rm: cannot remove '/app/pgcat.profdata': No such file or directory
main-1 exited with code 1
Aborting on container exit...
[+] Stopping 6/6
 ✔ Container docker-pg3-1   Stopped                                                                                                                                                                                                             0.5s 
 ✔ Container docker-pg1-1   Stopped                                                                                                                                                                                                             0.6s 
 ✔ Container docker-pg5-1   Stopped                                                                                                                                                                                                             0.5s 
 ✔ Container docker-pg2-1   Stopped                                                                                                                                                                                                             0.5s 
 ✔ Container docker-pg4-1   Stopped                                                                                                                                                                                                             0.5s 
 ✔ Container docker-main-1  Stopped                                                                                                                                                                                                             0.0s 
```