### PR TITLE
fix(helm): expose prometheus metrics port for scraping if enabled

### DIFF
--- a/charts/pgcat/Chart.yaml
+++ b/charts/pgcat/Chart.yaml
@@ -5,4 +5,4 @@ maintainers:
   - name: PostgresML
     email: team@postgresml.org
 appVersion: "1.3.0"
-version: 0.2.5
+version: 0.2.6

--- a/charts/pgcat/templates/deployment.yaml
+++ b/charts/pgcat/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "pgcat.fullname" . }}
   labels:
     {{- include "pgcat.labels" . | nindent 4 }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -36,6 +40,11 @@ spec:
             - name: pgcat
               containerPort: {{ .Values.configuration.general.port }}
               protocol: TCP
+            {{- if .Values.configuration.general.enable_prometheus_exporter }}
+            - name: metrics
+              containerPort: {{ .Values.configuration.general.prometheus_exporter_port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             tcpSocket:
               port: pgcat


### PR DESCRIPTION
Revamp of https://github.com/postgresml/pgcat/pull/889

Tested with 
```yaml
configuration:
    general:
      enable_prometheus_exporter: true
  podAnnotations:
    prometheus.io/path: /metrics
    prometheus.io/port: "9930"
    prometheus.io/scrape: "true"
```

and it works well