### PR TITLE
Allow plugins and query_parser_read_write_splitting without globally enabling query_parser_enabled

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -723,15 +723,13 @@ impl Pool {
         }
 
         if self.query_parser_read_write_splitting && !self.query_parser_enabled {
-            error!(
+            warn!(
                 "query_parser_read_write_splitting is only valid when query_parser_enabled is true"
             );
-            return Err(Error::BadConfig);
         }
 
         if self.plugins.is_some() && !self.query_parser_enabled {
-            error!("plugins are only valid when query_parser_enabled is true");
-            return Err(Error::BadConfig);
+            warn!("plugins are only valid when query_parser_enabled is true");
         }
 
         self.automatic_sharding_key = match &self.automatic_sharding_key {


### PR DESCRIPTION
## Summary

With this PR it will be possible to use it following way

Config:
```
query_parser_enabled = false
query_parser_read_write_splitting = true
```

Example:
```sql
SET SERVER ROLE to 'auto' -- it will enable query parser in place
SET PRIMARY READS TO 'off' -- it will disable reads from primary
SELECT * FROM users WHERE id = <id> LIMIT 1
-- any other reads

-- following statement will be routed to primary and succeed
UPDATE users SET updated_at = NOW() WHERE id = 1

SET PRIMARY READS TO 'default' -- return default value
SET SERVER ROLE to 'default' -- return default role
```

Without `query_parser_read_write_splitting` `auto` will randomly route to primary and replica

Let me know what do you think about it.
