### PR TITLE
initialDelaySeconds: 5 added to deployment.yaml

### DIFF
--- a/charts/pgcat/templates/deployment.yaml
+++ b/charts/pgcat/templates/deployment.yaml
@@ -39,9 +39,11 @@ spec:
           livenessProbe:
             tcpSocket:
               port: pgcat
+            initialDelaySeconds: 5
           readinessProbe:
             tcpSocket:
               port: pgcat
+            initialDelaySeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Related to issue https://github.com/postgresml/pgcat/issues/939.

Pgcat pod rollout will not cause connection drops.